### PR TITLE
Added PurchaseEntry + some other changes

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -221,7 +221,7 @@ class Connection {
             $this->division = $me->find()->CurrentDivision;
         }
 
-        $this->client()->setBaseUrl($this->client()->getBaseUrl() . '/' . $this->division);
+        $this->client()->setBaseUrl($this->apiUrl . '/' . $this->division);
     }
 
     /**

--- a/src/Picqer/Financials/Exact/Persistance/Storable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Storable.php
@@ -22,11 +22,17 @@ trait Storable {
 
     public function update()
     {
-        return $this->connection()->put($this->url . "(guid'$this->attributes[$this->primaryKey]')", $this->json());
+        $key = $this->primaryKey;
+        $primarykey = $this->$key;
+
+        return $this->connection()->put($this->url . "(guid'$primarykey')", $this->json());
     }
 
     public function delete()
     {
-        return $this->connection()->delete($this->url . "(guid'$this->attributes[$this->primaryKey]')");
+        $key = $this->primaryKey;
+        $primarykey = $this->$key;
+
+        return $this->connection()->delete($this->url . "(guid'$primarykey')");
     }
 }

--- a/src/Picqer/Financials/Exact/Persistance/Storable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Storable.php
@@ -22,11 +22,15 @@ trait Storable {
 
     public function update()
     {
-        return $this->connection()->put($this->url . "(guid'$this->primaryKey')", $this->json());
+        $key = $this->primaryKey;
+
+        return $this->connection()->put($this->url . "(guid'$this->$key')", $this->json());
     }
 
     public function delete()
     {
-        return $this->connection()->delete($this->url . "(guid'$this->primaryKey')");
+        $key = $this->primaryKey;
+
+        return $this->connection()->delete($this->url . "(guid'$this->$key')");
     }
 }

--- a/src/Picqer/Financials/Exact/Persistance/Storable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Storable.php
@@ -22,15 +22,11 @@ trait Storable {
 
     public function update()
     {
-        $key = $this->primaryKey;
-
-        return $this->connection()->put($this->url . "(guid'$this->$key')", $this->json());
+        return $this->connection()->put($this->url . "(guid'$this->attributes[$this->primaryKey]')", $this->json());
     }
 
     public function delete()
     {
-        $key = $this->primaryKey;
-
-        return $this->connection()->delete($this->url . "(guid'$this->$key')");
+        return $this->connection()->delete($this->url . "(guid'$this->attributes[$this->primaryKey]')");
     }
 }

--- a/src/Picqer/Financials/Exact/PurchaseEntry.php
+++ b/src/Picqer/Financials/Exact/PurchaseEntry.php
@@ -2,15 +2,15 @@
 
 class PurchaseEntry extends Model
 {
-
     use Query\Findable;
     use Persistance\Storable;
 
     protected $primaryKey = 'EntryID';
 
-    protected $purchaseEntryLines = [ ];
+    protected $purchaseEntryLines = [];
 
     protected $fillable = [
+        'EntryID',
         'BatchNumber',
         'Currency',
         'Description',
@@ -34,13 +34,14 @@ class PurchaseEntry extends Model
         'YourRef',
     ];
 
-
     public function addItem(array $array)
     {
-        if ( ! isset( $this->attributes['PurchaseEntryLines'] ) || $this->attributes['PurchaseEntryLines'] == null) {
+        if ( ! isset($this->attributes['PurchaseEntryLines']) || $this->attributes['PurchaseEntryLines'] == null)
+        {
             $this->attributes['PurchaseEntryLines'] = [];
         }
-        if ( ! isset( $array['LineNumber'] )) {
+        if ( ! isset($array['LineNumber']))
+        {
             $array['LineNumber'] = count($this->attributes['PurchaseEntryLines']) + 1;
         }
         $this->attributes['PurchaseEntryLines'][] = $array;

--- a/src/Picqer/Financials/Exact/PurchaseEntry.php
+++ b/src/Picqer/Financials/Exact/PurchaseEntry.php
@@ -1,0 +1,52 @@
+<?php namespace Picqer\Financials\Exact;
+
+class PurchaseEntry extends Model
+{
+
+    use Query\Findable;
+    use Persistance\Storable;
+
+    protected $primaryKey = 'EntryID';
+
+    protected $purchaseEntryLines = [ ];
+
+    protected $fillable = [
+        'BatchNumber',
+        'Currency',
+        'Description',
+        'Document',
+        'DueDate',
+        'EntryDate',
+        'EntryNumber',
+        'ExternalLinkReference',
+        'InvoiceNumber',
+        'Journal',
+        'OrderNumber',
+        'PaymentCondition',
+        'ProcessNumber',
+        'PurchaseEntryLines',
+        'Rate',
+        'ReportingPeriod',
+        'ReportingYear',
+        'Reversal',
+        'Supplier',
+        'VATAmountFC',
+        'YourRef',
+    ];
+
+
+    public function addItem(array $array)
+    {
+        if ( ! isset( $this->attributes['PurchaseEntryLines'] ) || $this->attributes['PurchaseEntryLines'] == null) {
+            $this->attributes['PurchaseEntryLines'] = [];
+        }
+        if ( ! isset( $array['LineNumber'] )) {
+            $array['LineNumber'] = count($this->attributes['PurchaseEntryLines']) + 1;
+        }
+        $this->attributes['PurchaseEntryLines'][] = $array;
+    }
+
+
+    protected $url = 'purchaseentry/PurchaseEntries';
+
+}

--- a/src/Picqer/Financials/Exact/PurchaseEntryLine.php
+++ b/src/Picqer/Financials/Exact/PurchaseEntryLine.php
@@ -2,7 +2,6 @@
 
 class PurchaseEntryLine extends Model
 {
-
     use Query\Findable;
     use Persistance\Storable;
 

--- a/src/Picqer/Financials/Exact/PurchaseEntryLine.php
+++ b/src/Picqer/Financials/Exact/PurchaseEntryLine.php
@@ -1,0 +1,32 @@
+<?php namespace Picqer\Financials\Exact;
+
+class PurchaseEntryLine extends Model
+{
+
+    use Query\Findable;
+    use Persistance\Storable;
+
+    protected $fillable = [
+        'ID',
+        'AmountFC',
+        'Asset',
+        'CostCenter',
+        'CostUnit',
+        'Description',
+        'EntryID',
+        'GLAccount',
+        'Notes',
+        'Project',
+        'Quantity',
+        'SerialNumber',
+        'Subscription',
+        'TrackingNumber',
+        'VATAmountFC',
+        'VATBaseAmountFC',
+        'VATCode',
+        'VATPercentage',
+    ];
+
+    protected $url = 'purchaseentry/PurchaseEntryLines';
+
+}

--- a/src/Picqer/Financials/Exact/Transactions.php
+++ b/src/Picqer/Financials/Exact/Transactions.php
@@ -26,5 +26,5 @@ class Transactions extends Model
         'TypeDescription'
     ];
 
-    protected $url = 'financialtransaction/Transactions/';
+    protected $url = 'financialtransaction/Transactions';
 }


### PR DESCRIPTION
I made several changes to your super library! Hopefully this wil make sense, if you have questions or comments let me know!

1. I added the ```purchaseentry/PurchaseEntries``` and ```purchaseentry/PurchaseEntryLines```

2. Also removed a slash in url of the Transaction model

3. Also this PR fixes UPDATE & DELETE requests, the Primary key value was never inserted in the URL, because it referenced only to the fieldname instead of the value.

4. Also there was a bug in the ```addDivisionNumberToApiUrl()``` function if you called something like this:

```
// Get the journals from our administration
        try {
            $journals = new \Picqer\Financials\Exact\Journal($connection);
            $result   = $journals->get();
            foreach ($result as $journal) {
                echo 'Journal: ' . $journal->Description . '<br>';
            }

            $result   = $journals->get(); // do another get

        } catch (\Exception $e) {
            echo get_class($e) . ' : ' . $e->getMessage();
        }
```
it will show this error:
```
Guzzle\Http\Exception\ClientErrorResponseException [ Error ]:
Client error response [status code] 404 [reason phrase] Not Found [url] https://start.exactonline.nl/api/v1/123456/123456/financial/Journals
```

As you can see it will try to create a new base url in function ```addDivisionNumberToApiUrl()``` but it uses not the API url but the Guzzle baseurl (which is set to https://start.exactonline.nl/api/v1/123456)