### PR TITLE
Added support for PrintedSalesInvoice

### DIFF
--- a/src/Picqer/Financials/Exact/PrintedSalesInvoice.php
+++ b/src/Picqer/Financials/Exact/PrintedSalesInvoice.php
@@ -1,0 +1,41 @@
+<?php namespace Picqer\Financials\Exact;
+
+class PrintedSalesInvoice extends Model
+{
+    protected $primaryKey = 'InvoiceID';
+
+    protected $fillable = [
+        'InvoiceID',
+        'Division',
+        'Document',
+        'DocumentCreationError',
+        'DocumentCreationSuccess',
+        'DocumentLayout',
+        'EmailCreationError',
+        'EmailCreationSuccess',
+        'EmailLayout',
+        'ExtraText',
+        'InvoiceDate',
+        'PostboxMessageCreationError',
+        'PostboxMessageCreationSuccess',
+        'PostboxSender',
+        'ReportingPeriod',
+        'ReportingYear',
+        'SendEmailToCustomer',
+        'SendInvoiceToCustomerPostbox',
+        'SendOutputBasedOnAccount',
+    ];
+
+    public function save()
+    {
+        return $this->insert();
+    }
+
+    public function insert()
+    {
+        return $this->connection()->post($this->url, $this->json());
+    }
+
+    protected $url = 'salesinvoice/PrintedSalesInvoices';
+
+}


### PR DESCRIPTION
Added PrintedSalesInvoice model to support processing SalesInvoices (printing/emailing). See https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesInvoicePrintedSalesInvoices

Fixes #31 