### PR TITLE
Add findWithSelect function

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -13,6 +13,17 @@ trait Findable
     }
 
 
+    public function findWithSelect($id, $select = '')
+    {
+        $result = $this->connection()->get($this->url, [
+            '$filter' => $this->primaryKey . " eq guid'$id'",
+            '$select' => $select
+        ]);
+        
+        return new self($this->connection(), $result);
+    }
+
+
     public function filter($filter, $expand = '', $select = '')
     {
         $request = [


### PR DESCRIPTION
In some cases when trying to access certain records like a purchase entry, a normal find() won't work because a select variable is required. Trying to access the record using the filter() function doesn't work.

Maybe you can add this untill a better fix is available?