### PR TITLE
Adds Symfony/Silex support and add Subscriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "picqer/exact-php-client",
+    "name": "marcelfw/exact-php-client",
     "type": "library",
     "description": "A PHP Client for the Exact API",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "marcelfw/exact-php-client",
+    "name": "picqer/exact-php-client",
     "type": "library",
     "description": "A PHP Client for the Exact API",
     "keywords": [

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -247,7 +247,7 @@ class Connection
     /**
      * @return string
      */
-    private function getAuthUrl()
+    public function getAuthUrl()
     {
         return $this->baseUrl . $this->authUrl . '?' . http_build_query(array(
             'client_id' => $this->exactClientId,

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -1,6 +1,6 @@
 <?php namespace Picqer\Financials\Exact;
 
-abstract class Model
+abstract class Model implements \JsonSerializable
 {
 
     /**
@@ -131,6 +131,16 @@ abstract class Model
     public function json()
     {
         return json_encode($this->attributes);
+    }
+
+    /**
+     * Return serializable data
+     * 
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->attributes;
     }
 
 }

--- a/src/Picqer/Financials/Exact/Subscriptions.php
+++ b/src/Picqer/Financials/Exact/Subscriptions.php
@@ -1,0 +1,54 @@
+<?php namespace Picqer\Financials\Exact;
+
+class Subscriptions extends Model
+{
+
+    use Query\Findable;
+    use Persistance\Storable;
+
+    protected $fillable = [
+        'BlockEntry',
+        'CancellationDate',
+        'Classification',
+        'ClassificationCode',
+        'ClassificationDescription',
+        'Created',
+        'Creator',
+        'CreatorFullName',
+        'Currency',
+        'CustomerPONumber',
+        'Description',
+        'Division',
+        'EndDate',
+        'InvoicedTo',
+        'InvoiceTo',
+        'InvoiceToContactPerson',
+        'InvoiceToContactPersonFullName',
+        'InvoiceToName',
+        'InvoicingStartDate',
+        'Modified',
+        'Modifier',
+        'ModifierFullName',
+        'Notes',
+        'Number',
+        'OrderedBy',
+        'OrderedByContactPerson',
+        'OrderedByContactPersonFullName',
+        'OrderedByName',
+        'PaymentCondition',
+        'PaymentConditionDescription',
+        'Printed',
+        'ReasonCancelled',
+        'ReasonCancelledCode',
+        'ReasonCancelledDescription',
+        'StartDate',
+        'SubscriptionLines',
+        'SubscriptionRestrictionEmployees',
+        'SubscriptionRestrictionItems',
+        'SubscriptionType',
+        'SubscriptionTypeCode',
+        'SubscriptionTypeDescription',
+    ];
+
+    protected $url = 'subscription/Subscriptions';
+}


### PR DESCRIPTION
Allow this library to be properly used within a Symfony and/or Silex project. You can now call getAuthUrl() yourself and let Symfony/Silex do the initial redirection.
Adds Subscriptions model to models.
Adds proper jsonSerializable() support.