### PR TITLE
Added StockPosition entity

### DIFF
--- a/src/Picqer/Financials/Exact/StockPosition.php
+++ b/src/Picqer/Financials/Exact/StockPosition.php
@@ -1,0 +1,34 @@
+<?php
+namespace Picqer\Financials\Exact;
+
+/**
+ * Entity holding stock position details.
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadLogisticsStockPosition
+ */
+class StockPosition extends Model
+{
+    use Query\Findable;
+
+    /**
+     * The fillable properties for the StockPosition model.
+     *
+     * @var string[]
+     */
+    protected $fillable = ['InStock', 'ItemId', 'PlanningIn', 'PlanningOut'];
+
+    /**
+     * The API request URL slug.
+     *
+     * @var string
+     */
+    protected $url = 'logistics/StockPosition';
+
+    /**
+     * The primary key for the current entity.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'ItemId';
+}

--- a/src/Picqer/Financials/Exact/StockPosition.php
+++ b/src/Picqer/Financials/Exact/StockPosition.php
@@ -6,6 +6,11 @@ namespace Picqer\Financials\Exact;
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadLogisticsStockPosition
+ *
+ * @property $InStock
+ * @property $ItemId
+ * @property $PlanningIn
+ * @property $PlanningOut
  */
 class StockPosition extends Model
 {


### PR DESCRIPTION
This should add the [StockPosition](https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadLogisticsStockPosition) entity. According to the API documentation, this entity is not Storable and as such, that corresponding trait has not been added in.