### PR TITLE
Refresh callback

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -43,6 +43,20 @@ function authorize()
 }
 
 /**
+ * Callback function that sets values that expire and are refreshed by Connection.
+ *
+ * @param Connection $connection
+ */
+function tokenUpdateCallback(\Picqer\Financials\Exact\Connection $connection) {
+    // Save the new tokens for next connections
+    setValue('accesstoken', $connection->getAccessToken());
+    setValue('refreshtoken', $connection->getRefreshToken());
+
+    // Save expires time for next connections
+    setValue('expires_in', $connection->getTokenExpires());
+}
+
+/**
  * Function to connect to Exact, this creates the client and automatically retrieves oAuth tokens if needed
  *
  * @return \Picqer\Financials\Exact\Connection
@@ -74,6 +88,8 @@ function connect()
     {
         $connection->setTokenExpires(getValue('expires_in'));
     }
+    
+    $connection->setTokenUpdateCallback('tokenUpdateCallback'); // Set callback to save newly generated tokens
 
     // Make the client connect and exchange tokens
     try {
@@ -81,13 +97,6 @@ function connect()
     } catch (\Exception $e) {
         throw new Exception('Could not connect to Exact: ' . $e->getMessage());
     }
-
-    // Save the new tokens for next connections
-    setValue('accesstoken', $connection->getAccessToken());
-    setValue('refreshtoken', $connection->getRefreshToken());
-
-    // Save expires time for next connections
-    setValue('expires_in', $connection->getTokenExpires());
 
     return $connection;
 }

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -440,7 +440,7 @@ class Connection
                 $this->tokenExpires = $this->getDateTimeFromExpires($body['expires_in']);
                 
                 if (is_callable($this->tokenUpdateCallback)) {
-                    call_user_func($this->tokenUpdateCallback, $connection);                    
+                    call_user_func($this->tokenUpdateCallback, $this);                    
                 }
             } else {
                 throw new ApiException('Could not acquire tokens, json decode failed. Got response: ' . $response->getBody()->getContents());

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -80,6 +80,11 @@ class Connection
      * @var Client
      */
     private $client;
+    
+    /**
+     * @var function(Connection)
+     */
+    private $tokenUpdateCallback;
 
     /**
      *
@@ -433,6 +438,10 @@ class Connection
                 $this->accessToken  = $body['access_token'];
                 $this->refreshToken = $body['refresh_token'];
                 $this->tokenExpires = $this->getDateTimeFromExpires($body['expires_in']);
+                
+                if (is_callable($this->tokenUpdateCallback)) {
+                    call_user_func($this->tokenUpdateCallback, $connection);                    
+                }
             } else {
                 throw new ApiException('Could not acquire tokens, json decode failed. Got response: ' . $response->getBody()->getContents());
             }
@@ -512,6 +521,13 @@ class Connection
     public function setDivision($division)
     {
         $this->division = $division;
+    }
+    
+    /**
+     * @param mixed $callback
+     */
+    public function setTokenUpdateCallback($callback) {
+        $this->tokenUpdateCallback = $callback;
     }
 
 

--- a/src/Picqer/Financials/Exact/Division.php
+++ b/src/Picqer/Financials/Exact/Division.php
@@ -32,6 +32,8 @@ class Division extends Model
 {
 
     use Query\Findable;
+    
+	protected $primaryKey = 'Code';
 
     protected $fillable = [
         'Code',

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -36,7 +36,13 @@ trait Findable
     public function findId($code, $key='Code'){
         if ( $this->isFillable($key) ) {
             $format = $this->url == 'crm/Accounts' ? '%18s' : '%s';
-            $format = is_string($code) ? "'$format'" : $format;
+            if (preg_match('/^[\w]{8}-([\w]{4}-){3}[\w]{12}$/', $code)) {
+                $format = "guid'$format'";
+            }
+            elseif (is_string($code)) {
+                $format = "'$format'";
+            }
+
             $filter = sprintf("$key eq $format", $code);
             $request = array('$filter' => $filter, '$top' => 1, '$orderby' => $this->primaryKey);
             if( $records = $this->connection()->get($this->url, $request) ){

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -36,7 +36,8 @@ trait Findable
     public function findId($code, $key='Code'){
         if ( $this->isFillable($key) ) {
             $format = $this->url == 'crm/Accounts' ? '%18s' : '%s';
-            $filter = sprintf("$key eq '$format'", $code);
+            $format = is_string($code) ? "'$format'" : $format;
+            $filter = sprintf("$key eq $format", $code);
             $request = array('$filter' => $filter, '$top' => 1, '$orderby' => $this->primaryKey);
             if( $records = $this->connection()->get($this->url, $request) ){
                 return $records[0][$this->primaryKey];

--- a/src/Picqer/Financials/Exact/ReceivableList.php
+++ b/src/Picqer/Financials/Exact/ReceivableList.php
@@ -1,9 +1,34 @@
 <?php namespace Picqer\Financials\Exact;
 
+/**
+ * Class ReceivableList
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadFinancialReceivablesList
+ *
+ * @property Int64 $HID Human readable ID, Primary key
+ * @property String $AccountCode Code of the Account
+ * @property Guid $AccountId Reference to the account
+ * @property String $AccountName Name of Account
+ * @property Double $Amount Amount
+ * @property Double $AmountInTransit Amount in transit
+ * @property String $CurrencyCode Code of Currency
+ * @property String $Description Description
+ * @property DateTime $DueDate Date the invoice should be paid
+ * @property Int32 $EntryNumber Entry number
+ * @property Guid $Id Obsolete
+ * @property DateTime $InvoiceDate Invoice date
+ * @property Int32 $InvoiceNumber Invoice number
+ * @property String $JournalCode Code of Journal
+ * @property String $JournalDescription Description of Journal
+ * @property String $YourRef Your reference
+ */
 class ReceivableList extends Model
 {
 
     use Query\Findable;
+
+	protected $primaryKey = 'HID';
 
     protected $fillable = [
 		'AccountCode',
@@ -15,6 +40,7 @@ class ReceivableList extends Model
 		'Description',
 		'DueDate',
 		'EntryNumber',
+		'HID',
 		'Id',
 		'InvoiceDate',
 		'InvoiceNumber',

--- a/src/Picqer/Financials/Exact/Subscription.php
+++ b/src/Picqer/Financials/Exact/Subscription.php
@@ -1,7 +1,7 @@
 <?php namespace Picqer\Financials\Exact;
 
 /**
- * Class Subscriptions
+ * Class Subscription
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
@@ -49,7 +49,7 @@
  * @property String $SubscriptionTypeCode Code of SubscriptionType
  * @property String $SubscriptionTypeDescription Description of SubscriptionType
  */
-class Subscriptions extends Model
+class Subscription extends Model
 {
 
     use Query\Findable;

--- a/src/Picqer/Financials/Exact/SubscriptionLine.php
+++ b/src/Picqer/Financials/Exact/SubscriptionLine.php
@@ -6,7 +6,7 @@ use Picqer\Financials\Exact\Persistance\Storable;
 use Picqer\Financials\Exact\Query\Findable;
 
 /**
- * Class Subscriptions
+ * Class SubscriptionLine
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
@@ -32,7 +32,7 @@ use Picqer\Financials\Exact\Query\Findable;
  * @property Double $VATAmountFC Vat Amount in the currency of the transaction
  * @property String $VATCode VATCode
  */
-class SubscriptionLines extends Model
+class SubscriptionLine extends Model
 {
 
     use Findable;

--- a/src/Picqer/Financials/Exact/SubscriptionType.php
+++ b/src/Picqer/Financials/Exact/SubscriptionType.php
@@ -6,7 +6,7 @@ use Picqer\Financials\Exact\Persistance\Storable;
 use Picqer\Financials\Exact\Query\Findable;
 
 /**
- * Class Subscriptions
+ * Class SubscriptionType
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
@@ -22,7 +22,7 @@ use Picqer\Financials\Exact\Query\Findable;
  * @property Guid $Modifier User ID of the last modifier
  * @property String $ModifierFullName Name of the last modifier
  */
-class SubscriptionTypes extends Model
+class SubscriptionType extends Model
 {
 
     use Findable;

--- a/src/Picqer/Financials/Exact/Subscriptions.php
+++ b/src/Picqer/Financials/Exact/Subscriptions.php
@@ -6,6 +6,7 @@
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
  *
+ * @property Guid $EntryID ID of the entry, Primary key
  * @property Boolean $BlockEntry Indicates if subscription is blocked for time cost entry
  * @property DateTime $CancellationDate Date of cancellation
  * @property Guid $Classification Reference to Classification
@@ -53,6 +54,8 @@ class Subscriptions extends Model
 
     use Query\Findable;
     use Persistance\Storable;
+    
+    protected $primaryKey = 'EntryID';
 
     protected $fillable = [
         'BlockEntry',
@@ -68,6 +71,7 @@ class Subscriptions extends Model
         'Description',
         'Division',
         'EndDate',
+        'EntryID',
         'InvoicedTo',
         'InvoiceTo',
         'InvoiceToContactPerson',

--- a/src/Picqer/Financials/Exact/Transaction.php
+++ b/src/Picqer/Financials/Exact/Transaction.php
@@ -1,0 +1,56 @@
+<?php namespace Picqer\Financials\Exact;
+
+/**
+ * Class Transaction
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=financialtransactionTransactions
+ *
+ * @property Guid $EntryID Primary key
+ * @property Double $ClosingBalanceFC Closing balance in the currency of the transaction
+ * @property DateTime $Date Creation date
+ * @property String $Description Description
+ * @property Int32 $Division Division code
+ * @property Int32 $EntryNumber Entry number
+ * @property Int16 $FinancialPeriod Financial period
+ * @property Int16 $FinancialYear Financial year
+ * @property String $JournalCode Code of Journal
+ * @property String $JournalDescription Description of Journal
+ * @property Double $OpeningBalanceFC Opening balance in the currency of the transaction
+ * @property String $PaymentConditionCode Code of PaymentCondition
+ * @property String $PaymentConditionDescription Description of PaymentCondition
+ * @property Int16 $Status Status: 5 = Rejected, 20 = Open, 50 = Processed
+ * @property String $StatusDescription Description of Status
+ * @property TransactionLines $TransactionLines Collection of lines
+ * @property Int32 $Type The transaction type. 10 = Opening balance, 20 = Sales entry, 21 = Sales credit note, 22 = Return invoice sent, 30 = Purchase entry, 31 = Purchase credit note, 32 = Return invoice received, 40 = Cash flow, 50 = VAT return, 70 = Asset depreciation, 71 = Asset investment, 72 = Asset revaluation, 73 = Asset transfer, 74 = Asset split, 75 = Asset discontinue, 76 = Asset sales, 80 = Revaluation, 82 = Exchange rate difference, 83 = Payment difference, 84 = Deferred revenue, 85 = Tracking number:Revaluation, 86 = Deferred cost, 90 = Other, 120 = Delivery, 121 = Sales return, 130 = Receipt, 131 = Purchase return, 140 = Shop order stock receipt, 141 = Shop order stock reversal, 142 = Issue to parent, 145 = Shop order time entry, 146 = Shop order time entry reversal, 150 = Requirement issue, 151 = Requirement reversal, 152 = Returned from parent, 155 = Subcontract Issue, 156 = Subcontract reversal, 158 = Shop order completed, 162 = Finish assembly, 170 = Payroll, 180 = Stock revaluation, 195 = Stock count, 290 = Correction entry, 310 = Period closing, 320 = Year end reflection, 321 = Year end costing, 322 = Year end profits to gross profit, 323 = Year end costs to gross profit, 324 = Year end tax, 325 = Year end gross profit to net p/l, 326 = Year end net p/l to balance sheet, 327 = Year end closing balance, 328 = Year start opening balance, 3000 = Budget
+ * @property String $TypeDescription The description of the transaction type
+ */
+class Transaction extends Model
+{
+    use Query\Findable;
+    use Persistance\Storable;
+    
+    protected $primaryKey = 'EntryID';
+    
+    protected $fillable = [
+        'ClosingBalanceFC',
+        'Date',
+        'Description',
+        'Division',
+        'EntryID',
+        'EntryNumber',
+        'FinancialPeriod',
+        'FinancialYear',
+        'JournalCode',
+        'JournalDescription',
+        'OpeningBalanceFC',
+        'PaymentConditionCode',
+        'PaymentConditionDescription',
+        'Status',
+        'StatusDescription',
+        'TransactionLines',
+        'Type',
+        'TypeDescription'
+    ];
+    protected $url = 'financialtransaction/Transactions';
+}

--- a/src/Picqer/Financials/Exact/Transactions.php
+++ b/src/Picqer/Financials/Exact/Transactions.php
@@ -1,56 +1,6 @@
 <?php namespace Picqer\Financials\Exact;
 
 /**
- * Class Transactions
- *
- * @package Picqer\Financials\Exact
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=financialtransactionTransactions
- *
- * @property Guid $EntryID Primary key
- * @property Double $ClosingBalanceFC Closing balance in the currency of the transaction
- * @property DateTime $Date Creation date
- * @property String $Description Description
- * @property Int32 $Division Division code
- * @property Int32 $EntryNumber Entry number
- * @property Int16 $FinancialPeriod Financial period
- * @property Int16 $FinancialYear Financial year
- * @property String $JournalCode Code of Journal
- * @property String $JournalDescription Description of Journal
- * @property Double $OpeningBalanceFC Opening balance in the currency of the transaction
- * @property String $PaymentConditionCode Code of PaymentCondition
- * @property String $PaymentConditionDescription Description of PaymentCondition
- * @property Int16 $Status Status: 5 = Rejected, 20 = Open, 50 = Processed
- * @property String $StatusDescription Description of Status
- * @property TransactionLines $TransactionLines Collection of lines
- * @property Int32 $Type The transaction type. 10 = Opening balance, 20 = Sales entry, 21 = Sales credit note, 22 = Return invoice sent, 30 = Purchase entry, 31 = Purchase credit note, 32 = Return invoice received, 40 = Cash flow, 50 = VAT return, 70 = Asset depreciation, 71 = Asset investment, 72 = Asset revaluation, 73 = Asset transfer, 74 = Asset split, 75 = Asset discontinue, 76 = Asset sales, 80 = Revaluation, 82 = Exchange rate difference, 83 = Payment difference, 84 = Deferred revenue, 85 = Tracking number:Revaluation, 86 = Deferred cost, 90 = Other, 120 = Delivery, 121 = Sales return, 130 = Receipt, 131 = Purchase return, 140 = Shop order stock receipt, 141 = Shop order stock reversal, 142 = Issue to parent, 145 = Shop order time entry, 146 = Shop order time entry reversal, 150 = Requirement issue, 151 = Requirement reversal, 152 = Returned from parent, 155 = Subcontract Issue, 156 = Subcontract reversal, 158 = Shop order completed, 162 = Finish assembly, 170 = Payroll, 180 = Stock revaluation, 195 = Stock count, 290 = Correction entry, 310 = Period closing, 320 = Year end reflection, 321 = Year end costing, 322 = Year end profits to gross profit, 323 = Year end costs to gross profit, 324 = Year end tax, 325 = Year end gross profit to net p/l, 326 = Year end net p/l to balance sheet, 327 = Year end closing balance, 328 = Year start opening balance, 3000 = Budget
- * @property String $TypeDescription The description of the transaction type
+ * Added deprecated Transactions class for backward compatibility
  */
-class Transactions extends Model
-{
-    use Query\Findable;
-    use Persistance\Storable;
-    
-    protected $primaryKey = 'EntryID';
-    
-    protected $fillable = [
-        'ClosingBalanceFC',
-        'Date',
-        'Description',
-        'Division',
-        'EntryID',
-        'EntryNumber',
-        'FinancialPeriod',
-        'FinancialYear',
-        'JournalCode',
-        'JournalDescription',
-        'OpeningBalanceFC',
-        'PaymentConditionCode',
-        'PaymentConditionDescription',
-        'Status',
-        'StatusDescription',
-        'TransactionLines',
-        'Type',
-        'TypeDescription'
-    ];
-    protected $url = 'financialtransaction/Transactions';
-}
+class_alias(__NAMESPACE__ . '\Transaction', __NAMESPACE__ . '\Transactions');

--- a/src/Picqer/Financials/Exact/Transactions.php
+++ b/src/Picqer/Financials/Exact/Transactions.php
@@ -6,6 +6,7 @@
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=financialtransactionTransactions
  *
+ * @property Guid $EntryID Primary key
  * @property Double $ClosingBalanceFC Closing balance in the currency of the transaction
  * @property DateTime $Date Creation date
  * @property String $Description Description
@@ -36,6 +37,7 @@ class Transactions extends Model
         'Date',
         'Description',
         'Division',
+        'EntryID',
         'EntryNumber',
         'FinancialPeriod',
         'FinancialYear',


### PR DESCRIPTION
When Connection->createRequest() gets called after 10 minutes (or possibly sooner when setTokenExpires is used) the Connection class nicely fetches new tokens. The Connection user is not notified and will when used as in the examples never save these updated tokens.
Last time I checked not saving the refresh token results in requiring reauthorisation of the app.