### PR TITLE
Lazyload

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -347,15 +347,16 @@ class Connection
             Psr7\rewind_body($response);
             $json = json_decode($response->getBody()->getContents(), true);
             if (array_key_exists('d', $json)) {
+                if (array_key_exists('__next', $json['d'])) {
+                    $this->nextUrl = $json['d']['__next'];
+                }
+                else {
+                    $this->nextUrl = null;
+                }
+
                 if (array_key_exists('results', $json['d'])) {
                     if (count($json['d']['results']) == 1) {
                         return $json['d']['results'][0];
-                    }
-                    if (array_key_exists('__next', $json['d'])) {
-                        $this->nextUrl = $json['d']['__next'];
-                    }
-                    else {
-                        $this->nextUrl = null;
                     }
 
                     return $json['d']['results'];

--- a/src/Picqer/Financials/Exact/Division.php
+++ b/src/Picqer/Financials/Exact/Division.php
@@ -32,6 +32,8 @@ class Division extends Model
 {
 
     use Query\Findable;
+    
+	protected $primaryKey = 'Code';
 
     protected $fillable = [
         'Code',

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -19,6 +19,11 @@ abstract class Model implements \JsonSerializable
      * @var array The model's attributes
      */
     protected $attributes = [ ];
+    
+    /**
+     * @deferred array The model's collection values
+     */
+    protected $deferred = [ ];
 
     /**
      * @var array The model's fillable attributes
@@ -107,10 +112,45 @@ abstract class Model implements \JsonSerializable
     {
         $this->attributes[$key] = $value;
     }
+    
+    /**
+     * Resolve deferred values
+     *
+     * @param string $key
+     *
+     * @return boolian returns true when collection is found.
+     */
+    protected function lazyLoad($key) {
+        // Check previously resolved or manualy set.
+        if (isset($this->deferred[$key])) {
+            return TRUE;
+        }
 
+        try {
+            if(is_array($this->attributes[$key]) && array_key_exists('__deferred', $this->attributes[$key])) {
+                $class = preg_replace('/(.+?)s?$/', __NAMESPACE__ . '\\\$1', $key); // Filter plural 's' and add namespace
+                $deferred = new $class($this->connection());
+                $uri = $this->attributes[$key]['__deferred']['uri'];
+                $deferred->connection()->nextUrl = $uri; // $uri is complete, by setting it to nextUrl Connection->formatUrl leaves it as is.
+                $result = $deferred->connection()->get($uri);
+                $this->deferred[$key] = $deferred->collectionFromResult($result);
+
+                return TRUE;
+            }
+        }
+        catch (Exception $e) {
+            // We tried lets leave it as is.
+        }
+
+        return FALSE;
+    }
 
     public function __get($key)
     {
+        if ($this->lazyLoad($key)) {
+            return $this->deferred[$key];
+        }
+        
         if (isset( $this->attributes[$key] )) {
             return $this->attributes[$key];
         }
@@ -120,6 +160,11 @@ abstract class Model implements \JsonSerializable
     public function __set($key, $value)
     {
         if ($this->isFillable($key)) {
+            if (is_array($value)) {
+                $this->deferred[$key] = $value;
+                return;
+            }
+
             return $this->setAttribute($key, $value);
         }
     }
@@ -151,9 +196,27 @@ abstract class Model implements \JsonSerializable
      *
      * @return string
      */
-    public function json($options = 0)
+    public function json($options = 0, $withDeferred = FALSE)
     {
-        return json_encode($this->attributes, $options);
+        $attributes = $this->attributes;
+        if ($withDeferred) {
+            foreach($this->deferred as $attribute => $collection) {
+                if (empty($collection)) {
+                    continue; // Leave orriginal array with __deferred key
+                }
+
+                $attributes[$attribute] = [];
+                foreach ($collection as $value) {
+                    if (is_a($value, 'Picqer\Financials\Exact\Model')) {
+                        array_push($attributes[$attribute], $value->attributes);
+                    } else {
+                        array_push($attributes[$attribute], $value);
+                    }
+                }
+            }
+        }
+
+        return json_encode($attributes, $options);
     }
 
 

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -69,6 +69,14 @@ abstract class Model implements \JsonSerializable
         return $this->attributes;
     }
 
+    /**
+     * Get the model's primary key
+     *
+     * @return string
+     */
+    public function primaryKey() {
+        return $this->primaryKey;
+    }
 
     /**
      * Fill the entity from an array
@@ -123,7 +131,7 @@ abstract class Model implements \JsonSerializable
     protected function lazyLoad($key) {
         // Check previously resolved or manualy set.
         if (isset($this->deferred[$key])) {
-            return TRUE;
+            return true;
         }
 
         try {
@@ -135,14 +143,14 @@ abstract class Model implements \JsonSerializable
                 $result = $deferred->connection()->get($uri);
                 $this->deferred[$key] = $deferred->collectionFromResult($result);
 
-                return TRUE;
+                return true;
             }
         }
         catch (Exception $e) {
             // We tried lets leave it as is.
         }
 
-        return FALSE;
+        return false;
     }
 
     public function __get($key)
@@ -196,7 +204,7 @@ abstract class Model implements \JsonSerializable
      *
      * @return string
      */
-    public function json($options = 0, $withDeferred = FALSE)
+    public function json($options = 0, $withDeferred = false)
     {
         $attributes = $this->attributes;
         if ($withDeferred) {

--- a/src/Picqer/Financials/Exact/Persistance/Storable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Storable.php
@@ -17,7 +17,7 @@ trait Storable {
 
     public function insert()
     {
-        return $this->connection()->post($this->url, $this->json());
+        return $this->connection()->post($this->url, $this->json(0, TRUE));
     }
 
     public function update()

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -36,7 +36,13 @@ trait Findable
     public function findId($code, $key='Code'){
         if ( $this->isFillable($key) ) {
             $format = $this->url == 'crm/Accounts' ? '%18s' : '%s';
-            $format = is_string($code) ? "'$format'" : $format;
+            if (preg_match('/^[\w]{8}-([\w]{4}-){3}[\w]{12}$/', $code)) {
+                $format = "guid'$format'";
+            }
+            elseif (is_string($code)) {
+                $format = "'$format'";
+            }
+
             $filter = sprintf("$key eq $format", $code);
             $request = array('$filter' => $filter, '$top' => 1, '$orderby' => $this->primaryKey);
             if( $records = $this->connection()->get($this->url, $request) ){

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -36,7 +36,8 @@ trait Findable
     public function findId($code, $key='Code'){
         if ( $this->isFillable($key) ) {
             $format = $this->url == 'crm/Accounts' ? '%18s' : '%s';
-            $filter = sprintf("$key eq '$format'", $code);
+            $format = is_string($code) ? "'$format'" : $format;
+            $filter = sprintf("$key eq $format", $code);
             $request = array('$filter' => $filter, '$top' => 1, '$orderby' => $this->primaryKey);
             if( $records = $this->connection()->get($this->url, $request) ){
                 return $records[0][$this->primaryKey];

--- a/src/Picqer/Financials/Exact/ReceivableList.php
+++ b/src/Picqer/Financials/Exact/ReceivableList.php
@@ -1,9 +1,34 @@
 <?php namespace Picqer\Financials\Exact;
 
+/**
+ * Class ReceivableList
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadFinancialReceivablesList
+ *
+ * @property Int64 $HID Human readable ID, Primary key
+ * @property String $AccountCode Code of the Account
+ * @property Guid $AccountId Reference to the account
+ * @property String $AccountName Name of Account
+ * @property Double $Amount Amount
+ * @property Double $AmountInTransit Amount in transit
+ * @property String $CurrencyCode Code of Currency
+ * @property String $Description Description
+ * @property DateTime $DueDate Date the invoice should be paid
+ * @property Int32 $EntryNumber Entry number
+ * @property Guid $Id Obsolete
+ * @property DateTime $InvoiceDate Invoice date
+ * @property Int32 $InvoiceNumber Invoice number
+ * @property String $JournalCode Code of Journal
+ * @property String $JournalDescription Description of Journal
+ * @property String $YourRef Your reference
+ */
 class ReceivableList extends Model
 {
 
     use Query\Findable;
+
+	protected $primaryKey = 'HID';
 
     protected $fillable = [
 		'AccountCode',
@@ -15,6 +40,7 @@ class ReceivableList extends Model
 		'Description',
 		'DueDate',
 		'EntryNumber',
+		'HID',
 		'Id',
 		'InvoiceDate',
 		'InvoiceNumber',

--- a/src/Picqer/Financials/Exact/Subscription.php
+++ b/src/Picqer/Financials/Exact/Subscription.php
@@ -1,7 +1,7 @@
 <?php namespace Picqer\Financials\Exact;
 
 /**
- * Class Subscriptions
+ * Class Subscription
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
@@ -49,7 +49,7 @@
  * @property String $SubscriptionTypeCode Code of SubscriptionType
  * @property String $SubscriptionTypeDescription Description of SubscriptionType
  */
-class Subscriptions extends Model
+class Subscription extends Model
 {
 
     use Query\Findable;

--- a/src/Picqer/Financials/Exact/SubscriptionLine.php
+++ b/src/Picqer/Financials/Exact/SubscriptionLine.php
@@ -6,7 +6,7 @@ use Picqer\Financials\Exact\Persistance\Storable;
 use Picqer\Financials\Exact\Query\Findable;
 
 /**
- * Class Subscriptions
+ * Class SubscriptionLine
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
@@ -32,7 +32,7 @@ use Picqer\Financials\Exact\Query\Findable;
  * @property Double $VATAmountFC Vat Amount in the currency of the transaction
  * @property String $VATCode VATCode
  */
-class SubscriptionLines extends Model
+class SubscriptionLine extends Model
 {
 
     use Findable;

--- a/src/Picqer/Financials/Exact/SubscriptionType.php
+++ b/src/Picqer/Financials/Exact/SubscriptionType.php
@@ -6,7 +6,7 @@ use Picqer\Financials\Exact\Persistance\Storable;
 use Picqer\Financials\Exact\Query\Findable;
 
 /**
- * Class Subscriptions
+ * Class SubscriptionType
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
@@ -22,7 +22,7 @@ use Picqer\Financials\Exact\Query\Findable;
  * @property Guid $Modifier User ID of the last modifier
  * @property String $ModifierFullName Name of the last modifier
  */
-class SubscriptionTypes extends Model
+class SubscriptionType extends Model
 {
 
     use Findable;

--- a/src/Picqer/Financials/Exact/Subscriptions.php
+++ b/src/Picqer/Financials/Exact/Subscriptions.php
@@ -6,6 +6,7 @@
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=subscriptionSubscriptions
  *
+ * @property Guid $EntryID ID of the entry, Primary key
  * @property Boolean $BlockEntry Indicates if subscription is blocked for time cost entry
  * @property DateTime $CancellationDate Date of cancellation
  * @property Guid $Classification Reference to Classification
@@ -53,6 +54,8 @@ class Subscriptions extends Model
 
     use Query\Findable;
     use Persistance\Storable;
+    
+    protected $primaryKey = 'EntryID';
 
     protected $fillable = [
         'BlockEntry',
@@ -68,6 +71,7 @@ class Subscriptions extends Model
         'Description',
         'Division',
         'EndDate',
+        'EntryID',
         'InvoicedTo',
         'InvoiceTo',
         'InvoiceToContactPerson',

--- a/src/Picqer/Financials/Exact/Transaction.php
+++ b/src/Picqer/Financials/Exact/Transaction.php
@@ -1,0 +1,56 @@
+<?php namespace Picqer\Financials\Exact;
+
+/**
+ * Class Transaction
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=financialtransactionTransactions
+ *
+ * @property Guid $EntryID Primary key
+ * @property Double $ClosingBalanceFC Closing balance in the currency of the transaction
+ * @property DateTime $Date Creation date
+ * @property String $Description Description
+ * @property Int32 $Division Division code
+ * @property Int32 $EntryNumber Entry number
+ * @property Int16 $FinancialPeriod Financial period
+ * @property Int16 $FinancialYear Financial year
+ * @property String $JournalCode Code of Journal
+ * @property String $JournalDescription Description of Journal
+ * @property Double $OpeningBalanceFC Opening balance in the currency of the transaction
+ * @property String $PaymentConditionCode Code of PaymentCondition
+ * @property String $PaymentConditionDescription Description of PaymentCondition
+ * @property Int16 $Status Status: 5 = Rejected, 20 = Open, 50 = Processed
+ * @property String $StatusDescription Description of Status
+ * @property TransactionLines $TransactionLines Collection of lines
+ * @property Int32 $Type The transaction type. 10 = Opening balance, 20 = Sales entry, 21 = Sales credit note, 22 = Return invoice sent, 30 = Purchase entry, 31 = Purchase credit note, 32 = Return invoice received, 40 = Cash flow, 50 = VAT return, 70 = Asset depreciation, 71 = Asset investment, 72 = Asset revaluation, 73 = Asset transfer, 74 = Asset split, 75 = Asset discontinue, 76 = Asset sales, 80 = Revaluation, 82 = Exchange rate difference, 83 = Payment difference, 84 = Deferred revenue, 85 = Tracking number:Revaluation, 86 = Deferred cost, 90 = Other, 120 = Delivery, 121 = Sales return, 130 = Receipt, 131 = Purchase return, 140 = Shop order stock receipt, 141 = Shop order stock reversal, 142 = Issue to parent, 145 = Shop order time entry, 146 = Shop order time entry reversal, 150 = Requirement issue, 151 = Requirement reversal, 152 = Returned from parent, 155 = Subcontract Issue, 156 = Subcontract reversal, 158 = Shop order completed, 162 = Finish assembly, 170 = Payroll, 180 = Stock revaluation, 195 = Stock count, 290 = Correction entry, 310 = Period closing, 320 = Year end reflection, 321 = Year end costing, 322 = Year end profits to gross profit, 323 = Year end costs to gross profit, 324 = Year end tax, 325 = Year end gross profit to net p/l, 326 = Year end net p/l to balance sheet, 327 = Year end closing balance, 328 = Year start opening balance, 3000 = Budget
+ * @property String $TypeDescription The description of the transaction type
+ */
+class Transaction extends Model
+{
+    use Query\Findable;
+    use Persistance\Storable;
+    
+    protected $primaryKey = 'EntryID';
+    
+    protected $fillable = [
+        'ClosingBalanceFC',
+        'Date',
+        'Description',
+        'Division',
+        'EntryID',
+        'EntryNumber',
+        'FinancialPeriod',
+        'FinancialYear',
+        'JournalCode',
+        'JournalDescription',
+        'OpeningBalanceFC',
+        'PaymentConditionCode',
+        'PaymentConditionDescription',
+        'Status',
+        'StatusDescription',
+        'TransactionLines',
+        'Type',
+        'TypeDescription'
+    ];
+    protected $url = 'financialtransaction/Transactions';
+}

--- a/src/Picqer/Financials/Exact/Transactions.php
+++ b/src/Picqer/Financials/Exact/Transactions.php
@@ -1,56 +1,6 @@
 <?php namespace Picqer\Financials\Exact;
 
 /**
- * Class Transactions
- *
- * @package Picqer\Financials\Exact
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=financialtransactionTransactions
- *
- * @property Guid $EntryID Primary key
- * @property Double $ClosingBalanceFC Closing balance in the currency of the transaction
- * @property DateTime $Date Creation date
- * @property String $Description Description
- * @property Int32 $Division Division code
- * @property Int32 $EntryNumber Entry number
- * @property Int16 $FinancialPeriod Financial period
- * @property Int16 $FinancialYear Financial year
- * @property String $JournalCode Code of Journal
- * @property String $JournalDescription Description of Journal
- * @property Double $OpeningBalanceFC Opening balance in the currency of the transaction
- * @property String $PaymentConditionCode Code of PaymentCondition
- * @property String $PaymentConditionDescription Description of PaymentCondition
- * @property Int16 $Status Status: 5 = Rejected, 20 = Open, 50 = Processed
- * @property String $StatusDescription Description of Status
- * @property TransactionLines $TransactionLines Collection of lines
- * @property Int32 $Type The transaction type. 10 = Opening balance, 20 = Sales entry, 21 = Sales credit note, 22 = Return invoice sent, 30 = Purchase entry, 31 = Purchase credit note, 32 = Return invoice received, 40 = Cash flow, 50 = VAT return, 70 = Asset depreciation, 71 = Asset investment, 72 = Asset revaluation, 73 = Asset transfer, 74 = Asset split, 75 = Asset discontinue, 76 = Asset sales, 80 = Revaluation, 82 = Exchange rate difference, 83 = Payment difference, 84 = Deferred revenue, 85 = Tracking number:Revaluation, 86 = Deferred cost, 90 = Other, 120 = Delivery, 121 = Sales return, 130 = Receipt, 131 = Purchase return, 140 = Shop order stock receipt, 141 = Shop order stock reversal, 142 = Issue to parent, 145 = Shop order time entry, 146 = Shop order time entry reversal, 150 = Requirement issue, 151 = Requirement reversal, 152 = Returned from parent, 155 = Subcontract Issue, 156 = Subcontract reversal, 158 = Shop order completed, 162 = Finish assembly, 170 = Payroll, 180 = Stock revaluation, 195 = Stock count, 290 = Correction entry, 310 = Period closing, 320 = Year end reflection, 321 = Year end costing, 322 = Year end profits to gross profit, 323 = Year end costs to gross profit, 324 = Year end tax, 325 = Year end gross profit to net p/l, 326 = Year end net p/l to balance sheet, 327 = Year end closing balance, 328 = Year start opening balance, 3000 = Budget
- * @property String $TypeDescription The description of the transaction type
+ * Added deprecated Transactions class for backward compatibility
  */
-class Transactions extends Model
-{
-    use Query\Findable;
-    use Persistance\Storable;
-    
-    protected $primaryKey = 'EntryID';
-    
-    protected $fillable = [
-        'ClosingBalanceFC',
-        'Date',
-        'Description',
-        'Division',
-        'EntryID',
-        'EntryNumber',
-        'FinancialPeriod',
-        'FinancialYear',
-        'JournalCode',
-        'JournalDescription',
-        'OpeningBalanceFC',
-        'PaymentConditionCode',
-        'PaymentConditionDescription',
-        'Status',
-        'StatusDescription',
-        'TransactionLines',
-        'Type',
-        'TypeDescription'
-    ];
-    protected $url = 'financialtransaction/Transactions';
-}
+class_alias(__NAMESPACE__ . '\Transaction', __NAMESPACE__ . '\Transactions');

--- a/src/Picqer/Financials/Exact/Transactions.php
+++ b/src/Picqer/Financials/Exact/Transactions.php
@@ -6,6 +6,7 @@
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=financialtransactionTransactions
  *
+ * @property Guid $EntryID Primary key
  * @property Double $ClosingBalanceFC Closing balance in the currency of the transaction
  * @property DateTime $Date Creation date
  * @property String $Description Description
@@ -36,6 +37,7 @@ class Transactions extends Model
         'Date',
         'Description',
         'Division',
+        'EntryID',
         'EntryNumber',
         'FinancialPeriod',
         'FinancialYear',


### PR DESCRIPTION
Added lazyloading feature. Now $account->BankAccounts will return an array of BankAccount objects. Unfortunatly the Exact API is a bit inconsistent. When setting an array of BankAccounts to a new Account and than save results in an error (Account guid not provided O_o) while a new Subscription cant be saved without a vallid collection of SubscriptionLines. 

The feature is backward compatible with manually building the collections (nested arrays). Setting a single object to a collection attribute is not supported.

I have also added an PrimaryKey accessor to help with storing in a cache table and duplicate records. 