### PR TITLE
Extract Division from request @ financialtransaction/Transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 index.php
 storage.txt
 composer.lock
+.DS_Store

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -174,6 +174,22 @@ class Connection
     }
 
     /**
+     * @param array $params
+     * @return bool
+     */
+    private function extractDivision($params = []){
+        if(is_array($params)){
+            if(isset($params['$filter']) && is_string($params['$filter'])){
+                if(preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $params['$filter'], $m)){
+                    $this->division = trim($m[1]);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * @param $url
      * @param array $params
      * @return mixed
@@ -181,6 +197,8 @@ class Connection
      */
     public function get($url, array $params = [])
     {
+        $this->extractDivision($params);
+
         $url = $this->formatUrl($url, $url !== 'current/Me', $url == $this->nextUrl);
 
         try {


### PR DESCRIPTION
When getting [transactions](https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=FinancialTransactionTransactions) the transactions for the division from '/me' were loaded, since the URL is composed using this division.

Now, a `Division eq xxxx` match is made against the `$filter`. If a match is found, this will set the Division for the URL.