### PR TITLE
Extract Division from request @ financialtransaction/Transactions

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -48,7 +48,10 @@ trait Findable
     public function filter($filter, $expand = '', $select = '', $system_query_options = null)
     {
         $originalDivision = $this->connection()->getDivision();
-        if($this->url == 'financialtransaction/Transactions' && preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $divisionId)) $this->connection()->setDivision(trim($divisionId[1])); // Fix division
+
+        if ($this->url !== 'current/Me' && preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $divisionId)) {
+            $this->connection()->setDivision(trim($divisionId[1])); // Fix division
+        }
 
         $request = [
             '$filter' => $filter
@@ -67,7 +70,9 @@ trait Findable
 
         $result = $this->connection()->get($this->url, $request);
 
-        if(!empty($divisionId)) $this->connection()->setDivision($originalDivision); // Restore division
+        if (!empty($divisionId)) {
+            $this->connection()->setDivision($originalDivision); // Restore division
+        }
 
         return $this->collectionFromResult($result);
     }

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -44,6 +44,7 @@ trait Findable
         }
     }
 
+
     public function filter($filter, $expand = '', $select = '', $system_query_options = null)
     {
         $originalDivision = $this->connection()->getDivision();

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -44,9 +44,25 @@ trait Findable
         }
     }
 
+    private function fixDivision($filter){
+        $previousDivision = $this->connection()->getDivision();
+
+        if(isset($filter) && is_string($filter)){
+            if($this->url == 'financialtransaction/Transactions'){
+                if(preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $m)){
+                    $this->connection()->setDivision(trim($m[1]));
+                }
+            }
+        }
+
+        return $previousDivision;
+    }
 
     public function filter($filter, $expand = '', $select = '', $system_query_options = null)
     {
+        // Fix division
+        $previousDivision = $this->fixDivision($filter);
+
         $request = [
             '$filter' => $filter
         ];
@@ -63,6 +79,9 @@ trait Findable
         }
 
         $result = $this->connection()->get($this->url, $request);
+
+        // Restore division
+        $this->connection()->setDivision($previousDivision);
 
         return $this->collectionFromResult($result);
     }

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -50,7 +50,7 @@ trait Findable
         $originalDivision = $this->connection()->getDivision();
 
         if ($this->isFillable('Division') && preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $divisionId)) {
-            $this->connection()->setDivision(trim($divisionId[1])); // Fix division
+            $this->connection()->setDivision($divisionId[1]); // Fix division
         }
 
         $request = [

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -49,7 +49,7 @@ trait Findable
     {
         $originalDivision = $this->connection()->getDivision();
 
-        if ($this->url !== 'current/Me' && preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $divisionId)) {
+        if ($this->isFillable('Division') && preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $divisionId)) {
             $this->connection()->setDivision(trim($divisionId[1])); // Fix division
         }
 

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -44,22 +44,10 @@ trait Findable
         }
     }
 
-    private function fixDivision($filter){
-        $previousDivision = $this->connection()->getDivision();
-
-        if($this->url == 'financialtransaction/Transactions'){
-            if(preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $m)){
-                $this->connection()->setDivision(trim($m[1]));
-            }
-        }
-
-        return $previousDivision;
-    }
-
     public function filter($filter, $expand = '', $select = '', $system_query_options = null)
     {
-        // Fix division
-        $previousDivision = $this->fixDivision($filter);
+        $originalDivision = $this->connection()->getDivision();
+        if($this->url == 'financialtransaction/Transactions' && preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $divisionId)) $this->connection()->setDivision(trim($divisionId[1])); // Fix division
 
         $request = [
             '$filter' => $filter
@@ -78,8 +66,7 @@ trait Findable
 
         $result = $this->connection()->get($this->url, $request);
 
-        // Restore division
-        $this->connection()->setDivision($previousDivision);
+        if(!empty($divisionId)) $this->connection()->setDivision($originalDivision); // Restore division
 
         return $this->collectionFromResult($result);
     }

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -47,11 +47,9 @@ trait Findable
     private function fixDivision($filter){
         $previousDivision = $this->connection()->getDivision();
 
-        if(isset($filter) && is_string($filter)){
-            if($this->url == 'financialtransaction/Transactions'){
-                if(preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $m)){
-                    $this->connection()->setDivision(trim($m[1]));
-                }
+        if($this->url == 'financialtransaction/Transactions'){
+            if(preg_match("@Division[\t\r\n ]+eq[\t\r\n ]+([0-9]+)@i", $filter, $m)){
+                $this->connection()->setDivision(trim($m[1]));
             }
         }
 


### PR DESCRIPTION
Fix for division number in URL: redundant when filtering on `Division eq 1337`.

Improved version of fix in [pull request 82](https://github.com/picqer/exact-php-client/pull/82). Prevents users to use the `setDivision` method when already filtering for a division ID. 

Use case: when not using PHP, but PHP (this class) is still being used (under the hood). This is de case for [nodum aPaas](https://nodum.io) when doing something like this:

```twig
{% for division in [ 136107, 84319, 84324, 128622, 84927 ] %}
    {% set inkoopboek = api.Exact_Online.getTransactions( 
        "Division eq " ~ division ~ " and FinancialYear eq 2016 and JournalDescription eq 'Inkoopboek'",
        '', 'Date', {} 
    ) %}

    <h3>{{ division }}</h3>
    {{ inkoopboek|table }}
{% endfor %}
```