### PR TITLE
Fix: The Model breaks isset(). Every __get() requires an __isset().

### DIFF
--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -176,6 +176,10 @@ abstract class Model implements \JsonSerializable
             return $this->setAttribute($key, $value);
         }
     }
+    
+    public function __isset(string $name) {
+        return $this->__get($name) !== null;
+    }
 
     public function __call($name, $arguments)
     {


### PR DESCRIPTION
I ran into trouble when checking for disabled accounts.

```
// Activate inactive account
if (isset($account->EndDate)) {
   // Never executed. because isset always returns false...
    $account->EndDate = null; 
    $account->save();
}
```