### PR TITLE
Added download dialog to replace the textarea block

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -8,6 +8,28 @@
 // ==/UserScript==
 
 (function() {
+  var instant_download = false;
+
+  /** Add textarea to display php code **/
+  // Push current content to the left.
+  $('body > form').css('float', 'left');
+  $('body > form').css('width', '50%');
+  $('body > form').css('overflow', 'auto');
+
+  // Add textarea to body, css might need some work.
+  $('<a />', {
+    id : 'php_download',
+    text: 'Download Code',
+    style: 'margin: 10px; padding: 10px; color: white; background-color: red'
+  }).appendTo('body');
+
+  $('<br /><br />').appendTo('body');
+
+  $('<textarea/>', {
+    id : 'php',
+    style: 'min-height:800px; width: 47%; margin-left:10px;'
+  }).appendTo('body');
+
   /** Initialize variables **/
   var primarykey = 'ID';
   var data = {};
@@ -54,22 +76,20 @@
   phptxt += "\n\n    protected $url = '" + url + "';";
   phptxt += "\n\n}";
   
+  // Display php code
+  $('#php').text(phptxt);
+
   // Present the php code as a download
-  $("<a />", {
-    // if supported , set name of file
-    download: classname + ".php",
-    // set `href` to `objectURL` of `Blob` of `textarea` value
-    href: URL.createObjectURL(
+  $('#php_download').attr("href",
+    URL.createObjectURL(
       new Blob([phptxt], {
         type: "text/plain"
       })
     )
-  }).appendTo("body")[0].click();
-  
-  // remove appended `a` element after "Save File" dialog,
-  // `window` regains `focus` 
-  $(window).one("focus", function() {
-    $("a").last().remove()
-  })
+  ).attr('download', classname + '.php');
 
+  if (instant_download)
+  {
+    $('#php_download')[0].click();
+  }
 })();

--- a/userscript.js
+++ b/userscript.js
@@ -8,18 +8,6 @@
 // ==/UserScript==
 
 (function() {
-  /** Add textarea to display php code **/
-  // Push current content to the left.
-  $('body > form').css('float', 'left');
-  $('body > form').css('width', '50%');
-  $('body > form').css('overflow', 'auto');
-
-  // Add textarea to body, css might need some work.
-  $('<textarea/>', {
-    id : 'php',
-    style: 'min-height:800px; width: 47%; margin-left:10px;'
-  }).appendTo('body');
-
   /** Initialize variables **/
   var primarykey = 'ID';
   var data = {};
@@ -66,7 +54,22 @@
   phptxt += "\n\n    protected $url = '" + url + "';";
   phptxt += "\n\n}";
   
-  // Display php code
-  $('#php').text(phptxt);
+  // Present the php code as a download
+  $("<a />", {
+    // if supported , set name of file
+    download: classname + ".php",
+    // set `href` to `objectURL` of `Blob` of `textarea` value
+    href: URL.createObjectURL(
+      new Blob([phptxt], {
+        type: "text/plain"
+      })
+    )
+  }).appendTo("body")[0].click();
+  
+  // remove appended `a` element after "Save File" dialog,
+  // `window` regains `focus` 
+  $(window).one("focus", function() {
+    $("a").last().remove()
+  })
 
 })();


### PR DESCRIPTION
To make it easier to add new entities I have changed the Greasemonkey script userscript.js a bit, so it presents the download dialog instead of the textarea block.

This also gives the possibility to middle mouse click the url's in the Exact api doc, the script will then automatically give the download dialog, with the focus staying on the Exact api doc list. 