### PR TITLE
Use correct variable type for callback

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -82,7 +82,7 @@ class Connection
     private $client;
     
     /**
-     * @var function(Connection)
+     * @var callable(Connection)
      */
     private $tokenUpdateCallback;
 
@@ -525,7 +525,7 @@ class Connection
     }
     
     /**
-     * @param mixed $callback
+     * @param callable $callback
      */
     public function setTokenUpdateCallback($callback) {
         $this->tokenUpdateCallback = $callback;


### PR DESCRIPTION
For the `tokenUpdateCallback` property in the `Connection` class, the type should be `callable`, not `function` or `mixed`. This PR prevents warnings from linters and IDE's (such as web/PHPStorm). 

See also: https://www.phpdoc.org/docs/latest/guides/types.html#types-of-types