### PR TITLE
Added fillable EntryNumber and  BankStatementDocument in BankEntry.

### DIFF
--- a/src/Picqer/Financials/Exact/BankEntry.php
+++ b/src/Picqer/Financials/Exact/BankEntry.php
@@ -27,8 +27,10 @@ class BankEntry extends Model
     protected $fillable = [
         'EntryID',
         'BankEntryLines',
+        'BankStatementDocument',
         'ClosingBalanceFC',
         'Currency',
+        'EntryNumber',
         'FinancialPeriod',
         'FinancialYear',
         'JournalCode',


### PR DESCRIPTION
Two missing attributes. Did not include 'derived' attributes like BankStatementDocumentNumber and JournalDescription. Is there a guideline for including / excluding fillables? 