### PR TITLE
Fix for returning a single item for next url requests responses

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -193,7 +193,7 @@ class Connection
             $request = $this->createRequest('GET', $url, null, $params);
             $response = $this->client()->send($request);
 
-            return $this->parseResponse($response);
+            return $this->parseResponse($response, $url != $this->nextUrl);
         } catch (Exception $e) {
             $this->parseExceptionForErrorMessages($e);
         }
@@ -339,10 +339,11 @@ class Connection
 
     /**
      * @param Response $response
+     * @param bool $returnSingleIfPossible
      * @return mixed
      * @throws ApiException
      */
-    private function parseResponse(Response $response)
+    private function parseResponse(Response $response, $returnSingleIfPossible = true)
     {
         try {
 
@@ -361,7 +362,7 @@ class Connection
                 }
 
                 if (array_key_exists('results', $json['d'])) {
-                    if (count($json['d']['results']) == 1) {
+                    if ($returnSingleIfPossible && count($json['d']['results']) == 1) {
                         return $json['d']['results'][0];
                     }
 


### PR DESCRIPTION
I encountered the same problem as mentioned in #132. The problem exists for all models and all 'next' requests where only 1 item was left to return.

I created a fix in the Connection class, where the default behaviour is kept the same as currently done (to keep impact small, do I would rather see it the other way around). But when the get function is called with the same url as the nexturl an extra param is send to prevend that behaviour when parsing the response.