### PR TITLE
Added SalesOrder models

### DIFF
--- a/src/Picqer/Financials/Exact/SalesOrder.php
+++ b/src/Picqer/Financials/Exact/SalesOrder.php
@@ -1,0 +1,153 @@
+<?php namespace Picqer\Financials\Exact;
+
+/**
+ * Class SalesOrder
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesOrderSalesOrders
+ *
+ * @property Guid $OrderID Primary key
+ * @property Double $AmountDC Amount in the default currency of the company
+ * @property Double $AmountFC Amount in the currency of the transaction
+ * @property Int16 $ApprovalStatus Shows if this sales order is approved
+ * @property String $ApprovalStatusDescription Description of ApprovalStatus
+ * @property DateTime $Approved Approval datetime
+ * @property Guid $Approver User who approved the sales order
+ * @property String $ApproverFullName Name of approver
+ * @property DateTime $Created Creation date
+ * @property Guid $Creator User ID of creator
+ * @property String $CreatorFullName Name of creator
+ * @property String $Currency Currency code
+ * @property Guid $DeliverTo Reference to delivery customer
+ * @property Guid $DeliverToContactPerson Reference to contact person of delivery customer
+ * @property String $DeliverToContactPersonFullName Name of contact person of delivery customer
+ * @property String $DeliverToName Name of delivery customer
+ * @property Guid $DeliveryAddress Delivery address
+ * @property DateTime $DeliveryDate Delivery date
+ * @property Int16 $DeliveryStatus Shipping status
+ * @property String $DeliveryStatusDescription Description of DeliveryStatus
+ * @property String $Description Description
+ * @property Int32 $Division Division code
+ * @property Guid $Document Document that is manually linked to the sales order
+ * @property Int32 $DocumentNumber Number of the document
+ * @property String $DocumentSubject Subject of the document
+ * @property Int16 $InvoiceStatus Invoice status
+ * @property String $InvoiceStatusDescription Description of InvoiceStatus
+ * @property Guid $InvoiceTo Reference to the Customer who will receive the invoice
+ * @property Guid $InvoiceToContactPerson Reference to the Contact person of the customer who will receive the invoice
+ * @property String $InvoiceToContactPersonFullName Name of the contact person of the customer who will receive the invoice
+ * @property String $InvoiceToName Name of the customer who will receive the invoice
+ * @property DateTime $Modified Last modified date
+ * @property Guid $Modifier User ID of modifier
+ * @property String $ModifierFullName Name of modifier
+ * @property DateTime $OrderDate Order date
+ * @property Guid $OrderedBy Customer who ordered the sales order
+ * @property Guid $OrderedByContactPerson Contact person of the customer who ordered the sales order
+ * @property String $OrderedByContactPersonFullName Name of contact person of the customer who ordered the sales order
+ * @property String $OrderedByName Name of the customer who ordered the sales order
+ * @property Int32 $OrderNumber Number of sales order
+ * @property String $PaymentCondition The payment condition used for due date and discount calculation
+ * @property String $PaymentConditionDescription Description of PaymentCondition
+ * @property String $PaymentReference Payment reference for sales order
+ * @property String $Remarks Extra remarks
+ * @property SalesOrderLines $SalesOrderLines Collection of lines
+ * @property Guid $Salesperson Sales representative
+ * @property String $SalespersonFullName Name of sales representative
+ * @property Guid $ShippingMethod ShippingMethod
+ * @property String $ShippingMethodDescription Description of ShippingMethod
+ * @property Int16 $Status The status of the sales order. 12 = Open, 20 = Partial, 21 = Complete, 45 = Cancelled.
+ * @property String $StatusDescription Description of Status
+ * @property Guid $TaxSchedule Tax schedule linked
+ * @property String $TaxScheduleCode Code of the tax schedule
+ * @property String $TaxScheduleDescription Description of the tax schedule
+ * @property String $WarehouseCode Code of Warehouse
+ * @property String $WarehouseDescription Description of Warehouse
+ * @property Guid $WarehouseID Warehouse
+ * @property String $YourRef The reference number of the customer
+ */
+class SalesOrder extends Model
+{
+    use Query\Findable;
+    use Persistance\Storable;
+
+    protected $primaryKey = 'OrderID';
+
+    protected $saleOrderLines = [ ];
+
+    protected $fillable = [
+        'OrderID',
+        'AmountDC',
+        'AmountFC',
+        'ApprovalStatus',
+        'ApprovalStatusDescription',
+        'Approved',
+        'Approver',
+        'ApproverFullName',
+        'Created',
+        'Creator',
+        'CreatorFullName',
+        'Currency',
+        'DeliverTo',
+        'DeliverToContactPerson',
+        'DeliverToContactPersonFullName',
+        'DeliverToName',
+        'DeliveryAddress',
+        'DeliveryDate',
+        'DeliveryStatus',
+        'DeliveryStatusDescription',
+        'Description',
+        'Division',
+        'Document',
+        'DocumentNumber',
+        'DocumentSubject',
+        'InvoiceStatus',
+        'InvoiceStatusDescription',
+        'InvoiceTo',
+        'InvoiceToContactPerson',
+        'InvoiceToContactPersonFullName',
+        'InvoiceToName',
+        'Modified',
+        'Modifier',
+        'ModifierFullName',
+        'OrderDate',
+        'OrderedBy',
+        'OrderedByContactPerson',
+        'OrderedByContactPersonFullName',
+        'OrderedByName',
+        'OrderNumber',
+        'PaymentCondition',
+        'PaymentConditionDescription',
+        'PaymentReference',
+        'Remarks',
+        'SalesOrderLines',
+        'Salesperson',
+        'SalespersonFullName',
+        'ShippingMethod',
+        'ShippingMethodDescription',
+        'Status',
+        'StatusDescription',
+        'TaxSchedule',
+        'TaxScheduleCode',
+        'TaxScheduleDescription',
+        'WarehouseCode',
+        'WarehouseDescription',
+        'WarehouseID',
+        'YourRef',
+    ];
+
+    /**
+     * @param array $array
+     */
+    public function addItem(array $array)
+    {
+        if (!isset($this->attributes['SalesOrderLines']) || $this->attributes['SalesOrderLines'] == null) {
+            $this->attributes['SalesOrderLines'] = [];
+        }
+        if (!isset($array['LineNumber'])) {
+            $array['LineNumber'] = count($this->attributes['SalesOrderLines']) + 1;
+        }
+        $this->attributes['SalesOrderLines'][] = $array;
+    }
+
+    protected $url = 'salesorder/SalesOrders';
+}

--- a/src/Picqer/Financials/Exact/SalesOrderLine.php
+++ b/src/Picqer/Financials/Exact/SalesOrderLine.php
@@ -1,0 +1,111 @@
+<?php namespace Picqer\Financials\Exact;
+
+/**
+ * Class SalesOrderLine
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesOrderSalesOrderLines
+ *
+ * @property Guid $ID Primary key
+ * @property Double $AmountDC Amount in the default currency of the company
+ * @property Double $AmountFC Amount in the currency of the transaction
+ * @property String $CostCenter Reference to Cost center
+ * @property String $CostCenterDescription Description of CostCenter
+ * @property Double $CostPriceFC Item cost price
+ * @property String $CostUnit Reference to Cost unit
+ * @property String $CostUnitDescription Description of CostUnit
+ * @property DateTime $DeliveryDate Delivery date of this line
+ * @property String $Description Description
+ * @property Double $Discount Discount given on the default price. Discount = (DefaultPrice of Item - PriceItem in line) / DefaultPrice of Item
+ * @property Int32 $Division Division code
+ * @property Guid $Item Reference to the item that is sold in this sales order line
+ * @property String $ItemCode Code of Item
+ * @property String $ItemDescription Description of Item
+ * @property Guid $ItemVersion Item Version
+ * @property String $ItemVersionDescription Description of Item Version
+ * @property Int32 $LineNumber Line number
+ * @property Double $Margin Sales margin of the sales order line
+ * @property Double $NetPrice Net price of the sales order line
+ * @property String $Notes Extra notes
+ * @property Guid $OrderID The OrderID identifies the sales order. All the lines of a sales order have the same OrderID
+ * @property Int32 $OrderNumber Number of sales order
+ * @property Guid $Pricelist Price list
+ * @property String $PricelistDescription Description of Pricelist
+ * @property Guid $Project The project to which the sales order line is linked. The project can be different per line. Sometimes also the project in the header is filled although this is not really used
+ * @property String $ProjectDescription Description of Project
+ * @property Guid $PurchaseOrder Purchase order that is linked to the sales order
+ * @property Guid $PurchaseOrderLine Purchase order line of the purchase order that is linked to the sales order
+ * @property Int32 $PurchaseOrderLineNumber Number of the purchase order line
+ * @property Int32 $PurchaseOrderNumber Number of the purchase order
+ * @property Double $Quantity The number of items sold in default units. The quantity shown in the entry screen is Quantity * UnitFactor
+ * @property Double $QuantityDelivered The number of items delivered
+ * @property Double $QuantityInvoiced The number of items invoiced
+ * @property Guid $ShopOrder Reference to ShopOrder
+ * @property Guid $TaxSchedule Tax schedule linked
+ * @property String $TaxScheduleCode Code of the tax schedule
+ * @property String $TaxScheduleDescription Description of the tax schedule
+ * @property String $UnitCode Code of item unit
+ * @property String $UnitDescription Description of Unit
+ * @property Double $UnitPrice Price per unit in the currency of the transaction
+ * @property Byte $UseDropShipment Indicates if drop shipment is used (delivery directly to customer, invoice to wholesaler)
+ * @property Double $VATAmount VAT amount in the currency of the transaction
+ * @property String $VATCode VAT code
+ * @property String $VATCodeDescription Description of VATCode
+ * @property Double $VATPercentage The vat percentage of the VAT code. This is the percentage at the moment the sales order is created. It's also used for the default calculation of VAT amounts and VAT base amounts
+ */
+class SalesOrderLine extends Model
+{
+    use Query\Findable;
+    use Persistance\Storable;
+
+    protected $fillable = [
+        'ID',
+        'AmountDC',
+        'AmountFC',
+        'CostCenter',
+        'CostCenterDescription',
+        'CostPriceFC',
+        'CostUnit',
+        'CostUnitDescription',
+        'DeliveryDate',
+        'Description',
+        'Discount',
+        'Division',
+        'Item',
+        'ItemCode',
+        'ItemDescription',
+        'ItemVersion',
+        'ItemVersionDescription',
+        'LineNumber',
+        'Margin',
+        'NetPrice',
+        'Notes',
+        'OrderID',
+        'OrderNumber',
+        'Pricelist',
+        'PricelistDescription',
+        'Project',
+        'ProjectDescription',
+        'PurchaseOrder',
+        'PurchaseOrderLine',
+        'PurchaseOrderLineNumber',
+        'PurchaseOrderNumber',
+        'Quantity',
+        'QuantityDelivered',
+        'QuantityInvoiced',
+        'ShopOrder',
+        'TaxSchedule',
+        'TaxScheduleCode',
+        'TaxScheduleDescription',
+        'UnitCode',
+        'UnitDescription',
+        'UnitPrice',
+        'UseDropShipment',
+        'VATAmount',
+        'VATCode',
+        'VATCodeDescription',
+        'VATPercentage'
+    ];
+
+    protected $url = 'salesorder/SalesOrderLines';
+}


### PR DESCRIPTION
Although these models also exists in stalled PR https://github.com/picqer/exact-php-client/pull/104 these are not 100% complete (for example lacking the function to attach SalesOrderLines). 

PR should be drop-in.