### PR TITLE
Fix Findable trait due to breaking changes in Exact REST API

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -5,10 +5,12 @@ trait Findable
 
     public function find($id)
     {
-        $result = $this->connection()->get($this->url, [
-            '$filter' => $this->primaryKey . " eq guid'$id'"
+        $records = $this->connection()->get($this->url, [
+            '$filter' => $this->primaryKey . " eq guid'$id'",
+            '$top' => 1, // The result will always be 1 but on some entities Exact gives an error without it.
         ]);
 
+        $result = isset($records[0]) ? $records[0] : null;
         return new self($this->connection(), $result);
     }
 
@@ -44,7 +46,12 @@ trait Findable
             }
 
             $filter = sprintf("$key eq $format", $code);
-            $request = array('$filter' => $filter, '$top' => 1, '$orderby' => $this->primaryKey);
+            $request = [
+                '$filter' => $filter,
+                '$top' => 1,
+                '$select' => $this->primaryKey,
+                '$orderby' => $this->primaryKey,
+            ];
             if( $records = $this->connection()->get($this->url, $request) ){
                 return $records[0][$this->primaryKey];
             }


### PR DESCRIPTION
On some entities (like DirectDebitMandate) Findable::find() returns the 400 nonsense about not using $top or $select in the query. So not only is this error implemented highly inconsistently it also occurs when an UUID is supplied. I have reported this issue but there answer was simply fix your query.

Also Findable::findId() should only retrieve the primaryKey.