### PR TITLE
Minor clock drift can cause expired token usage.

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -485,7 +485,7 @@ class Connection
             return true;
         }
 
-        return $this->tokenExpires <= time();
+        return $this->tokenExpires <= time() + 10;
     }
 
     private function formatUrl($endPoint, $includeDivision = true, $formatNextUrl = false)


### PR DESCRIPTION
On longer runs I sometimes get an auth error. Adding a 10 second grace period seems to fix it without having a performance impact.