### PR TITLE
Fix __construct() error when record is not found (returning NULL where it should be an array)

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -10,7 +10,7 @@ trait Findable
             '$top' => 1, // The result will always be 1 but on some entities Exact gives an error without it.
         ]);
 
-        $result = isset($records[0]) ? $records[0] : null;
+        $result = isset($records[0]) ? $records[0] : [];
         return new self($this->connection(), $result);
     }
 


### PR DESCRIPTION
Commit [8d02072a39520366d721bcfcf4e45774aacb199e](https://github.com/picqer/exact-php-client/commit/8d02072a39520366d721bcfcf4e45774aacb199e?diff=split) results in:

` [Symfony\Component\Debug\Exception\FatalThrowableError]                                                                                                                         
  Type error: Argument 2 passed to Picqer\Financials\Exact\Model::__construct() must be of the type array, null given, called in /vendor/picqer/exact-php-client/src/Picqer/Financials/Exact/Query/Findable.php on line 14`

If find() is called for a record that (no longer) exists. 
