### PR TITLE
Add download method

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -258,6 +258,21 @@ class Connection
             $this->parseExceptionForErrorMessages($e);
         }
     }
+    
+    /**
+     * @param $url
+     * @param $filename
+     */
+    public function download($url, $filename)
+    {
+        try {
+            $request = $this->createRequest('GET', $url);
+            $response = $this->client()->send($request);
+            file_put_contents($filename, $response->getBody()->getContents());
+        } catch (Exception $e) {
+            throw new ApiException($e->getMessage());
+        }
+    }
 
     /**
      * @return string


### PR DESCRIPTION
When you request a document you get a download URL which is lives outside the API url.
This will allow you to download the document:

```php
// $attachment->Url = https://start.exactonline.nl/docs/SysAttachment.aspx?ID=875393e3-62f5-4db6-8e53-cd1fc00e2a58&_Division_=1783857
$connection->download(
    $attachment->Url,
    __DIR__ . '/invoice.pdf'
);
```