### PR TITLE
add first() method to qeuries

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -92,6 +92,20 @@ trait Findable
     }
 
 
+    /**
+     * Returns the first Financial model in by applying $top=1 to the query string.
+     * 
+     * @return \Picqer\Financials\Exact\Model|null
+     */
+    public function first()
+    {
+        $results = $this->filter('', '', '', ['$top'=> 1]);
+        $result = is_array($results) && count($results) > 0 ? $results[0] : null;
+
+        return $result;
+    }
+
+
     public function get()
     {
         $result = $this->connection()->get($this->url);


### PR DESCRIPTION
Love the package!

I added a method that makes getting the first result easier.

It allows you to replace the following code:
```php
$journalEntry = new GeneralJournalEntry($connection);
$journalEntries = reset($journalEntry->filter('', '', '', ['$top'=> 1]));
$journalEntry = reset($journalEntries);
var_dump($journalEntry);
```

With the following code:
```php
$journalEntry = new GeneralJournalEntry($connection);
var_dump($journalEntry->first());
```

It also allows things such as chaining with `find` where you know that you receive one result:
```php
$journalEntry = new GeneralJournalEntry($connection);
$journalEntry->find('aaaaaaaa-bbbb-cccc-dddd-ffffffff')->first();
```

Let me know what you think.