### PR TITLE
Allow find on 'Code' id

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -5,10 +5,10 @@ trait Findable
 
     public function find($id)
     {
+    	$filter = $this->primaryKey . " eq guid'$id'";
+
         if ($this->primaryKey === 'Code') {
             $filter = $this->primaryKey . " eq $id";
-        } else {
-            $filter = $this->primaryKey . " eq guid'$id'";
         }
         
         $records = $this->connection()->get($this->url, [

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -5,8 +5,14 @@ trait Findable
 
     public function find($id)
     {
+        if ($this->primaryKey === 'Code') {
+            $filter = $this->primaryKey . " eq $id";
+        } else {
+            $filter = $this->primaryKey . " eq guid'$id'";
+        }
+        
         $records = $this->connection()->get($this->url, [
-            '$filter' => $this->primaryKey . " eq guid'$id'",
+            '$filter' => $filter,
             '$top' => 1, // The result will always be 1 but on some entities Exact gives an error without it.
         ]);
 


### PR DESCRIPTION
Some objects, such as [Divisions](https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=hrmDivisions) use an integer ID, instead of the more common GUID. To do a filter on ID the syntax in the Exact API is slighty different:
`Code eq 5` 
versus
`EntryId eq guid'1a2b3c...'`

This PR allows doing a find() on both types of ID.

Example:
`
$division = (new Division($connection))->find($me->CurrentDivision);
`
