### PR TITLE
Allow adding of custom headers

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -183,15 +183,16 @@ class Connection
     /**
      * @param $url
      * @param array $params
+     * @param array $headers
      * @return mixed
      * @throws ApiException
      */
-    public function get($url, array $params = [])
+    public function get($url, array $params = [], array $headers = [])
     {
         $url = $this->formatUrl($url, $url !== 'current/Me', $url == $this->nextUrl);
 
         try {
-            $request = $this->createRequest('GET', $url, null, $params);
+            $request = $this->createRequest('GET', $url, null, $params, $headers);
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response, $url != $this->nextUrl);

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -59,7 +59,7 @@ trait Findable
     }
 
 
-    public function filter($filter, $expand = '', $select = '', $system_query_options = null)
+    public function filter($filter, $expand = '', $select = '', $system_query_options = null, array $headers = [])
     {
         $originalDivision = $this->connection()->getDivision();
 
@@ -82,7 +82,7 @@ trait Findable
             $request = array_merge($system_query_options, $request);
         }
 
-        $result = $this->connection()->get($this->url, $request);
+        $result = $this->connection()->get($this->url, $request, $headers);
 
         if (!empty($divisionId)) {
             $this->connection()->setDivision($originalDivision); // Restore division


### PR DESCRIPTION
To allow retrieving language sensitive properties (as described [here](
https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=LogisticsItems), for example), I'd like to add a header to the filter-request being sent to Exact. This PR makes that possible.

