### PR TITLE
bug fix: Handle next pages single result as an element of array

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -138,6 +138,12 @@ trait Findable
         while ($this->connection()->nextUrl !== null)
         {
             $nextResult = $this->connection()->get($this->connection()->nextUrl);
+            
+            // If we have one result which is not an assoc array, make it the first element of an array for the array_merge function
+            if ((bool) count(array_filter(array_keys($nextResult), 'is_string'))) {
+                $nextResult = [ $nextResult ];
+            }
+            
             $result = array_merge($result, $nextResult);
         }
         $collection = [ ];


### PR DESCRIPTION
- Handle next page single result from Exact API not delivered as an array of elements by making the single item the first element of an (new) array.

The _collectionFromResult()_ function from the **Findable** trait currently fails when loading a "nextUrl" 
page that contain a single result. This pull request creates a new array if needed with the single result from the "nextUrl" page as the first item in the array.