### PR TITLE
Check if $key exists before using it in Model

### DIFF
--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -134,7 +134,7 @@ abstract class Model implements \JsonSerializable
         }
 
         try {
-            if(is_array($this->attributes[$key]) && array_key_exists('__deferred', $this->attributes[$key])) {
+            if(array_key_exists($key, $this->attributes) && is_array($this->attributes[$key]) && array_key_exists('__deferred', $this->attributes[$key])) {
                 $class = preg_replace('/(.+?)s?$/', __NAMESPACE__ . '\\\$1', $key); // Filter plural 's' and add namespace
                 $deferred = new $class($this->connection());
                 $uri = $this->attributes[$key]['__deferred']['uri'];


### PR DESCRIPTION
Using $this->attributes[$key] can result in "Notice: Undefined index: $key in ..." messages. 
I have added a "array_key_exists" call at line 137 to prevent this message.