### PR TITLE
Adding deferred values from deferred attributes when $withDeferred is…

### DIFF
--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -218,6 +218,10 @@ abstract class Model implements \JsonSerializable
 
                 $attributes[$attribute] = [];
                 foreach ($collection as $value) {
+                    if(!empty($value->deferred)) {
+                        $value->attributes = array_merge($value->attributes, $value->deferred);
+                    }
+
                     if (is_a($value, 'Picqer\Financials\Exact\Model')) {
                         array_push($attributes[$attribute], $value->attributes);
                     } else {


### PR DESCRIPTION
Adding deferred values from deferred attributes when $withDeferred is true.

A little more info on this, when using the $withDeferred option I expected the function to also work for nested objects or values. These lines of codes will also honor the values of attributes with deferred options.

We ran across this issue when we used this library in combination with Exact. Tried to make a [GoodsDelivery](https://support.exactonline.com/community/s/knowledge-base#All-All-DNO-Content-restapibusinessexampleapigoodsdelivery) with GoodsDeliveryLines containing SerialNumbers. Although I can imagine you would run into this very same issue when using other endpoints aswell.

Both GoodsDeliveryLines and SerialsNumbers are regarded deferred in the Picqer library. Therefore excluding them in the ->json() function that ultimately gets called when sending your request to Exact.