### PR TITLE
Correct $item property

### DIFF
--- a/src/Picqer/Financials/Exact/SalesInvoiceLine.php
+++ b/src/Picqer/Financials/Exact/SalesInvoiceLine.php
@@ -24,7 +24,7 @@ namespace Picqer\Financials\Exact;
  * @property Guid $GLAccount The GL Account of the sales invoice line. This field is mandatory. This field is generated based on the revenue account of the item (or the related item group). G/L Account is also used to determine whether the costcenter / costunit is mandatory
  * @property String $GLAccountDescription Description of GLAccount
  * @property Guid $InvoiceID The InvoiceID identifies the sales invoice. All the lines of a sales invoice have the same InvoiceID
- * @property Double $Item Discount given on the default price. Discount = (DefaultPrice of Item - PriceItem in line) / DefaultPrice of Item
+ * @property Guid $Item Reference to the item that is sold in this sales invoice line
  * @property String $ItemCode Item code
  * @property String $ItemDescription Description of Item
  * @property Int32 $LineNumber Indicates the sequence of the lines within one invoice


### PR DESCRIPTION
Correct $item property from exact online docs, even though Guid isn't a PHP type or part of this library. Kept it as Guid to be the same as the rest of the  library.