### PR TITLE
added SalesOrder & SalesOrderLine info to SalesInvoiceLine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~4.0"
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.35"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.35"

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -116,6 +116,7 @@ class Connection
             'http_errors' => true,
             'handler' => $handlerStack,
             'expect' => false,
+            'verify' => false,
         ]);
 
         return $this->client;

--- a/src/Picqer/Financials/Exact/SalesInvoiceLine.php
+++ b/src/Picqer/Financials/Exact/SalesInvoiceLine.php
@@ -97,6 +97,9 @@ class SalesInvoiceLine extends Model
         'VATCode',
         'VATCodeDescription',
         'VATPercentage',
+        'SalesOrder',
+        'SalesOrderLine',
+        'SalesOrderNumber',
     ];
 
     protected $url = 'salesinvoice/SalesInvoiceLines';


### PR DESCRIPTION
There was no possibility to get the CostPriceFC (SalesOrderLine property)  for each SalesInvoiceLine because this client did not include those fields. But the Api does return them. So I just added those fields.