### PR TITLE
Add support for downloading item images.

### DIFF
--- a/src/Picqer/Financials/Exact/Item.php
+++ b/src/Picqer/Financials/Exact/Item.php
@@ -101,7 +101,7 @@ class Item extends Model
 {
     use Query\Findable;
     use Persistance\Storable;
-    use Persistance\Downloadable
+    use Persistance\Downloadable;
         
     protected $fillable = [
         'Barcode',

--- a/src/Picqer/Financials/Exact/Item.php
+++ b/src/Picqer/Financials/Exact/Item.php
@@ -93,12 +93,16 @@ namespace Picqer\Financials\Exact;
  * @property DateTime $StartDate Together with StartDate this determines if the item is active
  * @property Byte $Unit Indicates if the item is a time unit item (for example a labor hour item)
  * @property String $UnitDescription Description of Unit
+ * @property String PictureUrl
+ * @property String PictureThumbnailUrl
+ * @property String PictureName
  */
 class Item extends Model
 {
     use Query\Findable;
     use Persistance\Storable;
-
+    use Persistance\Downloadable
+        
     protected $fillable = [
         'Barcode',
         'ID',

--- a/src/Picqer/Financials/Exact/Item.php
+++ b/src/Picqer/Financials/Exact/Item.php
@@ -186,6 +186,9 @@ class Item extends Model
         'Stock',
         'Unit',
         'UnitDescription',
+        'PictureUrl',
+        'PictureThumbnailUrl',
+        'PictureName',
     ];
 
     protected $url = 'logistics/Items';

--- a/src/Picqer/Financials/Exact/Persistance/Downloadable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Downloadable.php
@@ -18,7 +18,7 @@ trait Downloadable
         $client = new Client();
 
         if ($this->Url) {
-            $uri = $this->Url;
+            $uri = $this->Url . '&Download=1';
         } elseif ($this->PictureUrl) {
             $uri = $this->PictureUrl;
         }

--- a/src/Picqer/Financials/Exact/Persistance/Downloadable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Downloadable.php
@@ -17,7 +17,11 @@ trait Downloadable
     {
         $client = new Client();
 
-        $uri = $this->Url . '&Download=1';
+        if ($this->Url) {
+            $uri = $this->Url;
+        } elseif ($this->PictureUrl) {
+            $uri = $this->PictureUrl;
+        }
 
         $headers = [
             'Accept' => 'application/json',


### PR DESCRIPTION
Hi,

This pull request adds support for downloading images attached to items. We do this by extending the Item properties with PictureUrl, PictureThumbnailUrl and PictureName. We've extended the Downloadable trait to support both the Url property used by DocumentAttachment and the PictureUrl property used by Item.

We've simply omitted thumbnail support because it would require implementing even more class specific logic into the trait.

This should also fix #108 

Please give feedback and we'll do our best to implement it.
