### PR TITLE
Correct function call to no longer pass one parameter to many

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Resultset.php
+++ b/src/Picqer/Financials/Exact/Query/Resultset.php
@@ -23,7 +23,7 @@ class Resultset
         $result = $this->connection->get($this->url, $this->params);
         $this->url = $this->connection->nextUrl;
         $this->params = null;
-        return $this->collectionFromResult($result, $this->class);
+        return $this->collectionFromResult($result);
     }
 
     public function hasMore()


### PR DESCRIPTION
This issue was discovered running [phpstan](https://github.com/phpstan/phpstan) with level 0.