### PR TITLE
Add type mapping in userscript.js to map API docs type to resp PHP type

### DIFF
--- a/src/Picqer/Financials/Exact/WebhookSubscription.php
+++ b/src/Picqer/Financials/Exact/WebhookSubscription.php
@@ -8,9 +8,15 @@ namespace Picqer\Financials\Exact;
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=webhooksWebhookSubscriptions
  *
- * @property  $ID
- * @property  $CallbackURL 
- * @property  $Topic 
+ * @property string $ID Primary key
+ * @property string $CallbackURL Callback URL endpoint
+ * @property string $ClientID OAuth client Id
+ * @property string $Created Creation date
+ * @property string $Creator User ID of creator
+ * @property string $CreatorFullName Name of creator
+ * @property string $Description Description of the OAuth Client
+ * @property int $Division Division code
+ * @property string $Topic Webhook subscription topic, e.g.: FinancialTransactions, Items, StockPositions
  */
 class WebhookSubscription extends Model
 {
@@ -18,8 +24,14 @@ class WebhookSubscription extends Model
     use Persistance\Storable;
 
     protected $fillable = [
-    	'ID',
+        'ID',
         'CallbackURL',
+        'ClientID',
+        'Created',
+        'Creator',
+        'CreatorFullName',
+        'Description',
+        'Division',
         'Topic',
     ];
 

--- a/userscript.js
+++ b/userscript.js
@@ -36,6 +36,17 @@
   // Fetch entity URL and strip '/api/v1/{division}/'
   var url = $('#serviceUri').text().replace(/^\/api\/v[0-9]\/[^/]+\//, '');
   var classname = url.replace(/.+\/(.+?)s?$/,'$1'); // Last part after slash should be the (plural) classname.
+  var mapType = function(type) {
+      switch (type.toLowerCase()) {
+          case "guid":
+          case "datetime":
+              return "string";
+          case "int32":
+              return "int";
+          default:
+              return type.toLowerCase()
+      }
+  }
   
   /** Fetch attribute information **/
   $('#referencetable tr input').each(function() {
@@ -59,12 +70,12 @@
   phptxt += "\n * @see " + window.location.href;
   phptxt += "\n *";
   $.each(data,function(attribute, info){
-    phptxt += "\n * @property " + info.type + " $" + attribute + " " + info.description;
+    phptxt += "\n * @property " + mapType(info.type) + " $" + attribute + " " + info.description;
   });
   phptxt += "\n */";
   
   // Build class
-  phptxt += "\nclass " + classname + " extends Model\n{\n\n    use Query\\Findable;\n    use Persistance\\Storable;";
+  phptxt += "\nclass " + classname + " extends Model\n{\n    use Query\\Findable;\n    use Persistance\\Storable;";
   if (primarykey != 'ID') {
     phptxt += "\n\n    protected $primaryKey = '" + primarykey + "';";
   }
@@ -74,7 +85,7 @@
   });
   phptxt += "\n    ];";
   phptxt += "\n\n    protected $url = '" + url + "';";
-  phptxt += "\n\n}";
+  phptxt += "\n}\n";
   
   // Display php code
   $('#php').text(phptxt);


### PR DESCRIPTION
After realising now what the user script does (Allowing for generic code generation between contributors) I added type mapping to the greasemonkey script to convert documented type into the respective PHP internal type used, and applied this for the WebhookSubscription entity.