### PR TITLE
Add the missing property RSIN to the account Entity

### DIFF
--- a/src/Picqer/Financials/Exact/Account.php
+++ b/src/Picqer/Financials/Exact/Account.php
@@ -105,6 +105,7 @@ namespace Picqer\Financials\Exact;
  * @property Boolean $Reseller Indicates whether the account is a reseller
  * @property String $ResellerCode Code of Reseller
  * @property String $ResellerName Name of Reseller
+ * @property String $RSIN Fiscal number for NL legislation
  * @property String $SalesCurrency Currency of Sales used for Time & Billing
  * @property String $SalesCurrencyDescription Description of SalesCurrency
  * @property string $SalesTaxSchedule Default tax schedule when creating sales orders or sales invoices
@@ -231,6 +232,7 @@ class Account extends Model
         'Reseller',
         'ResellerCode',
         'ResellerName',
+        'RSIN',
         'SalesCurrency',
         'SalesCurrencyDescription',
         'SalesTaxSchedule',


### PR DESCRIPTION
I added the missing property in the Account Entity for Fiscal number for NL legislation: RSIN