### PR TITLE
Fix PHPDoc properties

### DIFF
--- a/src/Picqer/Financials/Exact/PurchaseEntry.php
+++ b/src/Picqer/Financials/Exact/PurchaseEntry.php
@@ -38,7 +38,7 @@ namespace Picqer\Financials\Exact;
  * @property String $PaymentConditionDescription Description of PaymentCondition
  * @property String $PaymentReference The payment reference used for bank imports, VAT return and Tax reference
  * @property Int32 $ProcessNumber
- * @property PurchaseEntryLines $PurchaseEntryLines Collection of lines
+ * @property array $PurchaseEntryLines Collection of lines
  * @property Double $Rate Currency exchange rate
  * @property Int16 $ReportingPeriod Reporting period
  * @property Int16 $ReportingYear Reporting year

--- a/src/Picqer/Financials/Exact/SalesEntry.php
+++ b/src/Picqer/Financials/Exact/SalesEntry.php
@@ -44,7 +44,7 @@ namespace Picqer\Financials\Exact;
  * @property Int16 $ReportingPeriod The period of the transaction lines. The period should exist in the period date table
  * @property Int16 $ReportingYear The financial year to which the entry belongs. The financial year should exist in the period date table
  * @property Boolean $Reversal Indicates if amounts are reversed
- * @property SalesEntryLines $SalesEntryLines Collection of lines
+ * @property array $SalesEntryLines Collection of lines
  * @property Int16 $Status Status: 5 = Rejected, 20 = Open, 50 = Processed
  * @property String $StatusDescription Description of Status
  * @property Int32 $Type Type: 20 = Sales entry, 21 = Sales credit note


### PR DESCRIPTION
PHPStan doesn't like it:
```
  292    Access to offset 'results' on an unknown class Picqer\Financials\Exact\SalesEntryLines.
  310    Access to offset 'results' on an unknown class Picqer\Financials\Exact\PurchaseEntryLines.
```

It would be great if you could run PHPStan on this project. It finds a lot more issues like this and it will improve this library 💪 