### PR TITLE
#311: Locking callbacks for acquiring new refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ setValue('refreshtoken', $connection->getRefreshToken());
 
 // Optionally, save the expiry-timestamp. This prevents exchanging valid tokens (ie. saves you some requests)
 setValue('expires_in', $connection->getTokenExpires());
+
+// Optionally, set locking callbacks to prevent multiple request for acquiring a new refresh token with the same refresh token.
+$connection->setLockAcquireAccessTokenCallback('CALLBACK_FUNCTION');
+$connection->setReleaseAcquireAccessTokenCallback('CALLBACK_FUNCTION');
 ```
 
 ### About divisions (administrations)

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ setValue('refreshtoken', $connection->getRefreshToken());
 // Optionally, save the expiry-timestamp. This prevents exchanging valid tokens (ie. saves you some requests)
 setValue('expires_in', $connection->getTokenExpires());
 
-// Optionally, set locking callbacks to prevent multiple request for acquiring a new refresh token with the same refresh token.
-$connection->setLockAcquireAccessTokenCallback('CALLBACK_FUNCTION');
-$connection->setReleaseAcquireAccessTokenCallback('CALLBACK_FUNCTION');
+// Optionally, set the lock and unlock callbacks to prevent multiple request for acquiring a new refresh token with the same refresh token.
+$connection->setAcquireAccessTokenLockCallback('CALLBACK_FUNCTION');
+$connection->setAcquireAccessTokenUnlockCallback('CALLBACK_FUNCTION');
 ```
 
 ### About divisions (administrations)

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -91,12 +91,12 @@ class Connection
     /**
      * @var callable(Connection)
      */
-    private $lockAcquireAccessTokenCallback;
+    private $acquireAccessTokenLockCallback;
 
     /**
      * @var callable(Connection)
      */
-    private $releaseAcquireAccessTokenCallback;
+    private $acquireAccessTokenUnlockCallback;
 
     /**
      * @var callable[]
@@ -453,8 +453,8 @@ class Connection
 
 
         try {
-            if (is_callable($this->lockAcquireAccessTokenCallback)) {
-                call_user_func($this->lockAcquireAccessTokenCallback, $this);
+            if (is_callable($this->acquireAccessTokenLockCallback)) {
+                call_user_func($this->acquireAccessTokenLockCallback, $this);
             }
 
             $response = $this->client()->post($this->getTokenUrl(), $body);
@@ -476,8 +476,8 @@ class Connection
         } catch (BadResponseException $ex) {
             throw new ApiException('Could not acquire or refresh tokens [http ' . $ex->getResponse()->getStatusCode() . ']');
         } finally {
-            if (is_callable($this->releaseAcquireAccessTokenCallback)) {
-                call_user_func($this->releaseAcquireAccessTokenCallback, $this);
+            if (is_callable($this->acquireAccessTokenUnlockCallback)) {
+                call_user_func($this->acquireAccessTokenUnlockCallback, $this);
             }
         }
     }
@@ -557,15 +557,15 @@ class Connection
     /**
      * @param callable $callback
      */
-    public function setLockAcquireAccessTokenCallback($callback) {
-        $this->lockAcquireAccessTokenCallback = $callback;
+    public function setAcquireAccessTokenLockCallback($callback) {
+        $this->acquireAccessTokenLockCallback = $callback;
     }
 
     /**
      * @param callable $callback
      */
-    public function setReleaseAcquireAccessTokenCallback($callback) {
-        $this->releaseAcquireAccessTokenCallback = $callback;
+    public function setAcquireAccessTokenUnlockCallback($callback) {
+        $this->acquireAccessTokenUnlockCallback = $callback;
     }
 
     /**


### PR DESCRIPTION
Added two callbacks for locking and releasing the Connection::acquireAccessToken() method.

See #311 for more information.