### PR TITLE
Add DocumentCategory entity

### DIFF
--- a/src/Picqer/Financials/Exact/DocumentCategory.php
+++ b/src/Picqer/Financials/Exact/DocumentCategory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Picqer\Financials\Exact;
+
+/**
+ * Class DocumentCategory
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=DocumentsDocumentCategories
+ *
+ * @property string $ID Primary key
+ * @property string $Created Creation date
+ * @property string $Description Document category description
+ * @property string $Modified Last modified date
+ */
+class DocumentCategory extends Model
+{
+    use Query\Findable;
+
+    protected $fillable = [
+        'ID',
+        'Created',
+        'Description',
+        'Modified'
+    ];
+
+    protected $url = 'documents/DocumentCategories';
+}

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -110,6 +110,11 @@ class EntityTest extends TestCase
         $this->performEntityTest(\Picqer\Financials\Exact\DocumentAttachment::class);
     }
 
+    public function testDocumentCategoryEntity()
+    {
+        $this->performEntityTest(\Picqer\Financials\Exact\DocumentCategory::class);
+    }
+
     public function testDocumentTypeEntity()
     {
         $this->performEntityTest(\Picqer\Financials\Exact\DocumentType::class);


### PR DESCRIPTION
Add support for [DocumentCategory](https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=DocumentsDocumentCategories) entity.