### PR TITLE
Add RevenueList Entity

### DIFF
--- a/src/Picqer/Financials/Exact/RevenueList.php
+++ b/src/Picqer/Financials/Exact/RevenueList.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Picqer\Financials\Exact;
+
+/**
+ * Class RevenueList
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadFinancialRevenueList
+ *
+ * @property int $Year Year
+ * @property int $Period Period
+ * @property float $Amount amount of revenue
+ */
+
+class RevenueList extends Model
+{
+    use Query\Findable;
+
+    protected $primaryKey = 'Year';
+
+    protected $fillable = [
+        'Year',
+        'Period',
+        'Amount',
+    ];
+
+    protected $url = 'read/financial/RevenueList';
+}

--- a/src/Picqer/Financials/Exact/RevenueList.php
+++ b/src/Picqer/Financials/Exact/RevenueList.php
@@ -3,7 +3,7 @@
 namespace Picqer\Financials\Exact;
 
 /**
- * Class RevenueList
+ * Class RevenueList.
  *
  * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadFinancialRevenueList

--- a/src/Picqer/Financials/Exact/RevenueList.php
+++ b/src/Picqer/Financials/Exact/RevenueList.php
@@ -5,14 +5,12 @@ namespace Picqer\Financials\Exact;
 /**
  * Class RevenueList.
  *
- * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadFinancialRevenueList
  *
  * @property int $Year Year
  * @property int $Period Period
  * @property float $Amount amount of revenue
  */
-
 class RevenueList extends Model
 {
     use Query\Findable;

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -11,7 +11,6 @@ use Picqer\Financials\Exact\Connection;
  */
 class EntityTest extends TestCase
 {
-
     public function testAccountEntity()
     {
         $this->performEntityTest(\Picqer\Financials\Exact\Account::class);
@@ -475,5 +474,4 @@ class EntityTest extends TestCase
         $this->assertEquals('Picqer\Financials\Exact', $reflectionClass->getNamespaceName());
         $this->assertEquals('Picqer\Financials\Exact\Model', $reflectionClass->getParentClass()->getName());
     }
-
 }

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -255,6 +255,10 @@ class EntityTest extends TestCase
         $this->performEntityTest(\Picqer\Financials\Exact\PurchaseOrderLine::class);
     }
 
+    public function testRevenueListEntity(){
+        $this->performEntityTest(\Picqer\Financials\Exact\RevenueList::class);
+    }
+
     public function testQuotationEntity()
     {
         $this->performEntityTest(\Picqer\Financials\Exact\Quotation::class);

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 use Picqer\Financials\Exact\Connection;
 
 /**
- * Class EntityTest
+ * Class EntityTest.
  *
  * Tests all entities to ensure entities have no PHP parse errors and have
  * at least the properties we need to use the entity
@@ -255,7 +255,8 @@ class EntityTest extends TestCase
         $this->performEntityTest(\Picqer\Financials\Exact\PurchaseOrderLine::class);
     }
 
-    public function testRevenueListEntity(){
+    public function testRevenueListEntity()
+    {
         $this->performEntityTest(\Picqer\Financials\Exact\RevenueList::class);
     }
 


### PR DESCRIPTION
Simple addition of the RevenueList entity

https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadFinancialRevenueList

Results can be filtered by year and period.

Feel free to edit. 