### PR TITLE
Added Class BulkTransactionLine

### DIFF
--- a/src/Picqer/Financials/Exact/BulkTransactionLine.php
+++ b/src/Picqer/Financials/Exact/BulkTransactionLine.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Exact;
+
+use Picqer\Financials\Exact\TransactionLine;
+
+/**
+ * Class BulkTransactionLine
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=BulkFinancialTransactionLines
+ */
+class BulkTransactionLine extends TransactionLine
+{
+    protected $url = 'bulk/Financial/TransactionLines';
+}


### PR DESCRIPTION
We thought of two solutions:
1. Overwrite the url property of the TransactionLine class, however its not only a 'bulk' prefix the url is also slightly different 'financialtransaction/TransactionLines' => 'bulk/Financial/TransactionLines'.
2. Create a new class BulkTransactionLine

Please note we did not add an Entity Test because the parent class is Picqer\Financials\Exact\TransactionLine instead of Picqer\Financials\Exact\Model.

