### PR TITLE
Adds ability to read rate limits from Exact

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ By default the library will use the default administration of the user. This mea
 Exact uses a minutely and daily rate limit. There are a maximum number of calls per day you can do per company, and to prevent bursting they have also implemented a limit per minute. This PR stores this information in the `Connection` and adds methods to read the rate limits so you can handle these as appropriate for your app.
 Exact documentation on rate limits is found here: https://support.exactonline.com/community/s/knowledge-base#All-All-DNO-Simulation-gen-apilimits
 
+If you hit a rate limit, an `ApiException` will be thrown with code 429. At that point you can determine whether you've hit the minutely or the daily limit. If you've hit the minutely limit, try again after 60 seconds. If you've hit the daily limit, try again after the daily reset.
+
 You can use the following methods on the `Connection`, which will return the limits after your first API call (based on the headers from Exact).
 
 ```php

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ $connection->setAcquireAccessTokenUnlockCallback('CALLBACK_FUNCTION');
 
 By default the library will use the default administration of the user. This means that when the user switches administrations in Exact Online. The library will also start working with this administration.
 
+### Rate limits
+Exact uses a minutely and daily rate limit. There are a maximum number of calls per day you can do per company, and to prevent bursting they have also implemented a limit per minute. This PR stores this information in the `Connection` and adds methods to read the rate limits so you can handle these as appropriate for your app.
+Exact documentation on rate limits is found here: https://support.exactonline.com/community/s/knowledge-base#All-All-DNO-Simulation-gen-apilimits
+
+You can use the following methods on the `Connection`, which will return the limits after your first API call (based on the headers from Exact).
+
+```php
+$connection->getDailyLimit(); // Retrieve your daily limit
+$connection->getDailyLimitRemaining(); // Retrieve the remaining amount of API calls for this day
+$connection->getDailyLimitReset(); // Retrieve the timestamp for when the limit will reset
+$connection->getMinutelyLimit(); // Retrieve your limit per minute
+$connection->getMinutelyLimitRemaining(); // Retrieve the amount of API calls remaining for this minute
+```
+
 ### Use the library to do stuff (examples)
 
 ```php

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -628,7 +628,7 @@ class Connection
             $errorMessage = $responseBody;
         }
 
-        throw new ApiException('Error ' . $response->getStatusCode() . ': ' . $errorMessage);
+        throw new ApiException('Error ' . $response->getStatusCode() . ': ' . $errorMessage, $response->getStatusCode());
     }
 
     /**

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -632,7 +632,7 @@ class Connection
     }
 
     /**
-     * @return string|null The maximum number of API calls that your app is permitted to make per company, per day.
+     * @return string|null The maximum number of API calls that your app is permitted to make per company, per day
      */
     public function getDailyLimit()
     {
@@ -640,7 +640,7 @@ class Connection
     }
 
     /**
-     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per day.
+     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per day
      */
     public function getDailyLimitRemaining()
     {
@@ -648,7 +648,7 @@ class Connection
     }
 
     /**
-     * @return string|null The time at which the rate limit window resets in UTC epoch milliseconds.
+     * @return string|null The time at which the rate limit window resets in UTC epoch milliseconds
      */
     public function getDailyLimitReset()
     {
@@ -656,7 +656,7 @@ class Connection
     }
 
     /**
-     * @return string|null The maximum number of API calls that your app is permitted to make per company, per minute.
+     * @return string|null The maximum number of API calls that your app is permitted to make per company, per minute
      */
     public function getMinutelyLimit()
     {
@@ -664,7 +664,7 @@ class Connection
     }
 
     /**
-     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per minute.
+     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per minute
      */
     public function getMinutelyLimitRemaining()
     {
@@ -732,11 +732,11 @@ class Connection
 
     private function extractRateLimits(Response $response)
     {
-        $this->dailyLimit = (int)$response->getHeaderLine('X-RateLimit-Limit');
-        $this->dailyLimitRemaining = (int)$response->getHeaderLine('X-RateLimit-Remaining');
-        $this->dailyLimitReset = (int)$response->getHeaderLine('X-RateLimit-Reset');
+        $this->dailyLimit = (int) $response->getHeaderLine('X-RateLimit-Limit');
+        $this->dailyLimitRemaining = (int) $response->getHeaderLine('X-RateLimit-Remaining');
+        $this->dailyLimitReset = (int) $response->getHeaderLine('X-RateLimit-Reset');
 
-        $this->minutelyLimit = (int)$response->getHeaderLine('X-RateLimit-Minutely-Limit');
-        $this->minutelyLimitRemaining = (int)$response->getHeaderLine('X-RateLimit-Minutely-Remaining');
+        $this->minutelyLimit = (int) $response->getHeaderLine('X-RateLimit-Minutely-Limit');
+        $this->minutelyLimitRemaining = (int) $response->getHeaderLine('X-RateLimit-Minutely-Remaining');
     }
 }

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -632,7 +632,7 @@ class Connection
     }
 
     /**
-     * @return string|null The maximum number of API calls that your app is permitted to make per company, per day
+     * @return int|null The maximum number of API calls that your app is permitted to make per company, per day
      */
     public function getDailyLimit()
     {
@@ -640,7 +640,7 @@ class Connection
     }
 
     /**
-     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per day
+     * @return int|null The remaining number of API calls that your app is permitted to make for a company, per day
      */
     public function getDailyLimitRemaining()
     {
@@ -648,7 +648,7 @@ class Connection
     }
 
     /**
-     * @return string|null The time at which the rate limit window resets in UTC epoch milliseconds
+     * @return int|null The time at which the rate limit window resets in UTC epoch milliseconds
      */
     public function getDailyLimitReset()
     {
@@ -656,7 +656,7 @@ class Connection
     }
 
     /**
-     * @return string|null The maximum number of API calls that your app is permitted to make per company, per minute
+     * @return int|null The maximum number of API calls that your app is permitted to make per company, per minute
      */
     public function getMinutelyLimit()
     {
@@ -664,7 +664,7 @@ class Connection
     }
 
     /**
-     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per minute
+     * @return int|null The remaining number of API calls that your app is permitted to make for a company, per minute
      */
     public function getMinutelyLimitRemaining()
     {

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -106,6 +106,31 @@ class Connection
     public $nextUrl = null;
 
     /**
+     * @var int|null
+     */
+    protected $dailyLimit;
+
+    /**
+     * @var int|null
+     */
+    protected $dailyLimitRemaining;
+
+    /**
+     * @var int|null
+     */
+    protected $dailyLimitReset;
+
+    /**
+     * @var int|null
+     */
+    protected $minutelyLimit;
+
+    /**
+     * @var int|null
+     */
+    protected $minutelyLimitRemaining;
+
+    /**
      * @return Client
      */
     private function client()
@@ -367,6 +392,8 @@ class Connection
                 return [];
             }
 
+            $this->extractRateLimits($response);
+
             Psr7\rewind_body($response);
             $json = json_decode($response->getBody()->getContents(), true);
             if (array_key_exists('d', $json)) {
@@ -605,6 +632,46 @@ class Connection
     }
 
     /**
+     * @return string|null The maximum number of API calls that your app is permitted to make per company, per day.
+     */
+    public function getDailyLimit()
+    {
+        return $this->dailyLimit;
+    }
+
+    /**
+     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per day.
+     */
+    public function getDailyLimitRemaining()
+    {
+        return $this->dailyLimitRemaining;
+    }
+
+    /**
+     * @return string|null The time at which the rate limit window resets in UTC epoch milliseconds.
+     */
+    public function getDailyLimitReset()
+    {
+        return $this->dailyLimitReset;
+    }
+
+    /**
+     * @return string|null The maximum number of API calls that your app is permitted to make per company, per minute.
+     */
+    public function getMinutelyLimit()
+    {
+        return $this->minutelyLimit;
+    }
+
+    /**
+     * @return string|null The remaining number of API calls that your app is permitted to make for a company, per minute.
+     */
+    public function getMinutelyLimitRemaining()
+    {
+        return $this->minutelyLimitRemaining;
+    }
+
+    /**
      * @return string
      */
     protected function getBaseUrl()
@@ -661,5 +728,15 @@ class Connection
     public function setTokenUrl($tokenUrl)
     {
         $this->tokenUrl = $tokenUrl;
+    }
+
+    private function extractRateLimits(Response $response)
+    {
+        $this->dailyLimit = (int)$response->getHeaderLine('X-RateLimit-Limit');
+        $this->dailyLimitRemaining = (int)$response->getHeaderLine('X-RateLimit-Remaining');
+        $this->dailyLimitReset = (int)$response->getHeaderLine('X-RateLimit-Reset');
+
+        $this->minutelyLimit = (int)$response->getHeaderLine('X-RateLimit-Minutely-Limit');
+        $this->minutelyLimitRemaining = (int)$response->getHeaderLine('X-RateLimit-Minutely-Remaining');
     }
 }


### PR DESCRIPTION
Exact uses a minutely and daily rate limit. There are a maximum number of calls per day you can do per company, and to prevent bursting they have also implemented a limit per minute. This PR stores this information in the `Connection` and adds methods to read the rate limits so you can handle these as appropriate for your app.

Exact Docs: https://support.exactonline.com/community/s/knowledge-base#All-All-DNO-Simulation-gen-apilimits