### PR TITLE
Extract rate limits from bad API responses

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -618,6 +618,9 @@ class Connection
         }
 
         $response = $e->getResponse();
+        
+        $this->extractRateLimits($response);
+        
         Psr7\rewind_body($response);
         $responseBody = $response->getBody()->getContents();
         $decodedResponseBody = json_decode($responseBody, true);


### PR DESCRIPTION
In #363 the ability to read rate limits from Exact API responses has been added. This only works for successful responses though.

For bad responses (4xx or 5xx errors) the rate limit values will not be parsed. To be able to handle responses which are rate limited (status code 429) and determine which of the rate limits has been hit, they should be parsed for these responses as well. This PR will do that.