### PR TITLE
Move the access token payload builder below the access token lock callback

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -451,31 +451,31 @@ class Connection
 
     private function acquireAccessToken()
     {
-        // If refresh token not yet acquired, do token request
-        if (empty($this->refreshToken)) {
-            $body = [
-                'form_params' => [
-                    'redirect_uri'  => $this->redirectUrl,
-                    'grant_type'    => 'authorization_code',
-                    'client_id'     => $this->exactClientId,
-                    'client_secret' => $this->exactClientSecret,
-                    'code'          => $this->authorizationCode,
-                ],
-            ];
-        } else { // else do refresh token request
-            $body = [
-                'form_params' => [
-                    'refresh_token' => $this->refreshToken,
-                    'grant_type'    => 'refresh_token',
-                    'client_id'     => $this->exactClientId,
-                    'client_secret' => $this->exactClientSecret,
-                ],
-            ];
-        }
-
         try {
             if (is_callable($this->acquireAccessTokenLockCallback)) {
                 call_user_func($this->acquireAccessTokenLockCallback, $this);
+            }
+
+            // If refresh token not yet acquired, do token request
+            if (empty($this->refreshToken)) {
+                $body = [
+                    'form_params' => [
+                        'redirect_uri'  => $this->redirectUrl,
+                        'grant_type'    => 'authorization_code',
+                        'client_id'     => $this->exactClientId,
+                        'client_secret' => $this->exactClientSecret,
+                        'code'          => $this->authorizationCode,
+                    ],
+                ];
+            } else { // else do refresh token request
+                $body = [
+                    'form_params' => [
+                        'refresh_token' => $this->refreshToken,
+                        'grant_type'    => 'refresh_token',
+                        'client_id'     => $this->exactClientId,
+                        'client_secret' => $this->exactClientSecret,
+                    ],
+                ];
             }
 
             $response = $this->client()->post($this->getTokenUrl(), $body);


### PR DESCRIPTION
This ensures that the `setAcquireAccessTokenLockCallback` callback can overrule the `refreshToken`. 

Our use-case:

With multiple requests running at once and the accessToken needs to be updated, we run into a issue that multiple requests are refreshing the same refreshToken at once. We add a atomic lock in the `setAcquireAccessTokenLockCallback` callback, and when the lock was taken and then finished, we update the token again and let it refresh again.

This ensures that the new refresh token is added to the `acquireAccessToken` body correctly.

An even better solution for this problem would be to set the accessToken & refreshToken after the lock is released, but for this we must implemented a exit out of the `acquireAccessTokenLockCallback`.

Example (Laravel locking):
```
$lockOwner = Str::random(32);

$this->setAcquireAccessTokenLockCallback(function () use ($lockOwner) {
    /** @var Lock $lock */
    $lock = Cache::lock('exact:access-token:lock', 10, $lockOwner);

    if (!$lock->get()) {
        $lock->block(10);

        // This sets the new tokens from the other request that previously had the lock
        $this->setTokensFromClient(Client::active()->fresh());
    }
});

$this->setAcquireAccessTokenUnlockCallback(function () use ($lockOwner) {
    Cache::restoreLock('exact:access-token:lock', $lockOwner)->release();
});
```