### PR TITLE
Yield responses to prevent memory overflow

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -148,6 +148,10 @@ trait Findable
             $result = [$result];
         }
 
+        foreach($result as $row){
+            yield new self($this->connection(), $row);
+        }
+
         while ($this->connection()->nextUrl !== null) {
             $nextResult = $this->connection()->get($this->connection()->nextUrl);
 
@@ -156,13 +160,12 @@ trait Findable
                 $nextResult = [$nextResult];
             }
 
-            $result = array_merge($result, $nextResult);
-        }
-        $collection = [];
-        foreach ($result as $r) {
-            $collection[] = new self($this->connection(), $r);
+            foreach($nextResult as $row){
+                yield new self($this->connection(), $row);
+            }
         }
 
-        return $collection;
+
+        return;
     }
 }

--- a/src/Picqer/Financials/Exact/Query/Resultset.php
+++ b/src/Picqer/Financials/Exact/Query/Resultset.php
@@ -79,12 +79,9 @@ class Resultset
         }
 
         $class = $this->class;
-        $collection = [];
 
         foreach ($result as $r) {
-            $collection[] = new $class($this->connection, $r);
+           yield new $class($this->connection, $r);
         }
-
-        return $collection;
     }
 }


### PR DESCRIPTION
Instead of collecting all models in an array. Which can be troublesome on big administrations I've refactored the collectionFromResult methods to yield the Models from a request to Exact. 