### PR TITLE
Fix assumption that response decode is always ok

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -396,6 +396,10 @@ class Connection
 
             Psr7\rewind_body($response);
             $json = json_decode($response->getBody()->getContents(), true);
+            if (false === is_array($json))
+            {
+                throw new ApiException('JSON decode failed', 400);
+            }
             if (array_key_exists('d', $json)) {
                 if (array_key_exists('__next', $json['d'])) {
                     $this->nextUrl = $json['d']['__next'];


### PR DESCRIPTION
A failed decode throws a warning in current code.
"
...
/home/httpd/vhosts/example-domain.net/vendor/picqer/exact-php-client/src/Picqer/Financials/Exact/Query/Findable.php on line 109 in function get with args: <string>https://start.exactonline.nl/api/v1/1498802/logistics/Items, <array>array, <array>array,
/home/httpd/vhosts/example-domain.net/vendor/picqer/exact-php-client/src/Picqer/Financials/Exact/Connection.php on line 234 in function parseResponse with args: <object>GuzzleHttp\Psr7\Response, <boolean>1,
/home/httpd/vhosts/example-domain.net/vendor/picqer/exact-php-client/src/Picqer/Financials/Exact/Connection.php on line 399 in function array_key_exists with args: <string>d, <NULL>,
on line in function reportError with args: <integer>2, <string>array_key_exists() expects parameter 2 to be array, null given, <string>/home/httpd/vhosts/example-domain.net/vendor/picqer/exact-php-client/src/Picqer/Financials/Exact/Connection.php, <integer>399, <array>array,
"