### PR TITLE
Add From/To Properties to SalesEntryLine

### DIFF
--- a/src/Picqer/Financials/Exact/SalesEntryLine.php
+++ b/src/Picqer/Financials/Exact/SalesEntryLine.php
@@ -21,6 +21,7 @@ namespace Picqer\Financials\Exact;
  * @property string $EntryID The unique ID of the entry. Via this ID all transaction lines of a single entry can be retrieved
  * @property float $ExtraDutyAmountFC Extra duty amount in the currency of the transaction. Both extra duty amount and VAT amount need to be specified in order to differ this property from automatically calculated.
  * @property float $ExtraDutyPercentage Extra duty percentage for the item
+ * @property string $From From date to identify the range for deferred revenue. This is used in combination with the property 'To' that defines the end date
  * @property string $GLAccount The GL Account of the invoice line. This field is generated based on the revenue account of the item (or the related item group). G/L Account is also used to determine whether the costcenter / costunit is mandatory
  * @property string $GLAccountCode Code of GLAccount
  * @property string $GLAccountDescription Description of GLAccount
@@ -42,6 +43,7 @@ namespace Picqer\Financials\Exact;
  * @property string $Subscription When generating invoices from subscriptions, this field records the link between invoice lines and subscription lines
  * @property string $SubscriptionDescription Description of Subscription
  * @property string $TaxSchedule Obsolete
+ * @property string $To To date to identify the range for deferred revenue. This is used in combination with the property 'From' that defines the start date
  * @property string $TrackingNumber Reference to TrackingNumber
  * @property string $TrackingNumberDescription Description of TrackingNumber
  * @property int $Type Type: 20 = Sales entry, 21 = Sales credit note
@@ -73,6 +75,7 @@ class SalesEntryLine extends Model
         'EntryID',
         'ExtraDutyAmountFC',
         'ExtraDutyPercentage',
+        'From',
         'GLAccount',
         'GLAccountCode',
         'GLAccountDescription',
@@ -94,6 +97,7 @@ class SalesEntryLine extends Model
         'Subscription',
         'SubscriptionDescription',
         'TaxSchedule',
+        'To',
         'TrackingNumber',
         'TrackingNumberDescription',
         'Type',


### PR DESCRIPTION
The `From` and `To` properties are missing the in the `SalesEntryLine` which are necessary for the Deferred revenue

Please see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesEntrySalesEntryLines