### PR TITLE
Fix ResultSet with multiple pages

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Resultset.php
+++ b/src/Picqer/Financials/Exact/Query/Resultset.php
@@ -52,7 +52,7 @@ class Resultset
     {
         $result = $this->connection->get($this->url, $this->params);
         $this->url = $this->connection->nextUrl;
-        $this->params = null;
+        $this->params = [];
 
         return $this->collectionFromResult($result);
     }


### PR DESCRIPTION
$this->connection->get() requires the second parameter to be an array, null isn't accepted. We should therefor set $this->params to an empty array instead of null to prevent errors.