### PR TITLE
Add option to be able to upload WBS XMLs

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -281,7 +281,7 @@ class Connection
 
     /**
      * @param string $url
-     * @param mixed $body
+     * @param mixed  $body
      *
      * @throws ApiException
      *
@@ -289,10 +289,10 @@ class Connection
      */
     public function upload($topic, $body)
     {
-        $url = $this->getBaseUrl() . '/docs/XMLUpload.aspx?Topic=' . $topic .'&_Division=' . $this->getDivision();
+        $url = $this->getBaseUrl() . '/docs/XMLUpload.aspx?Topic=' . $topic . '&_Division=' . $this->getDivision();
 
         try {
-            $request  = $this->createRequest('POST', $url, $body);
+            $request = $this->createRequest('POST', $url, $body);
             $response = $this->client()->send($request);
 
             return $this->parseResponseXml($response);
@@ -475,7 +475,6 @@ class Connection
     private function parseResponseXml(Response $response)
     {
         try {
-
             if ($response->getStatusCode() === 204) {
                 return [];
             }
@@ -484,15 +483,13 @@ class Connection
             Psr7\rewind_body($response);
             $simpleXml = new \SimpleXMLElement($response->getBody()->getContents());
 
-            foreach ($simpleXml->Messages as $message)
-            {
-                $keyAlt          = (string) $message->Message->Topic->Data->attributes()['keyAlt'];
+            foreach ($simpleXml->Messages as $message) {
+                $keyAlt = (string) $message->Message->Topic->Data->attributes()['keyAlt'];
                 $answer[$keyAlt] = (string) $message->Message->Description;
             }
 
             return $answer;
-        }
-        catch (\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             throw new ApiException($e->getMessage());
         }
     }

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -281,6 +281,28 @@ class Connection
 
     /**
      * @param string $url
+     * @param mixed $body
+     *
+     * @throws ApiException
+     *
+     * @return mixed
+     */
+    public function upload($topic, $body)
+    {
+        $url = $this->getBaseUrl() . '/docs/XMLUpload.aspx?Topic=' . $topic .'&_Division=' . $this->getDivision();
+
+        try {
+            $request  = $this->createRequest('POST', $url, $body);
+            $response = $this->client()->send($request);
+
+            return $this->parseResponseXml($response);
+        } catch (Exception $e) {
+            $this->parseExceptionForErrorMessages($e);
+        }
+    }
+
+    /**
+     * @param string $url
      * @param mixed  $body
      *
      * @throws ApiException
@@ -439,6 +461,38 @@ class Connection
 
             return $json;
         } catch (\RuntimeException $e) {
+            throw new ApiException($e->getMessage());
+        }
+    }
+
+    /**
+     * @param Response $response
+     *
+     * @throws ApiException
+     *
+     * @return mixed
+     */
+    private function parseResponseXml(Response $response)
+    {
+        try {
+
+            if ($response->getStatusCode() === 204) {
+                return [];
+            }
+
+            $answer = [];
+            Psr7\rewind_body($response);
+            $simpleXml = new \SimpleXMLElement($response->getBody()->getContents());
+
+            foreach ($simpleXml->Messages as $message)
+            {
+                $keyAlt          = (string) $message->Message->Topic->Data->attributes()['keyAlt'];
+                $answer[$keyAlt] = (string) $message->Message->Description;
+            }
+
+            return $answer;
+        }
+        catch (\RuntimeException $e) {
             throw new ApiException($e->getMessage());
         }
     }


### PR DESCRIPTION
Hello,

This change allows for being able to upload WBS XMLs. 

In my project I use it as follows:
```php
/**
	 * Upload the WBS XML.
	 *
	 * @param   string  $projectGuid  The project GUID
	 * @param   int     $projectCode  The project ID
	 * @param   string  $location     The location
	 *
	 * @return  void
	 *
	 * @since   1.0.0
	 */
	private function uploadWbs(string $projectGuid, int $projectCode, string $location): void
	{
		$xml = '<?xml version="1.0" encoding="utf-8"?>
				<eExact xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="eExact-XML.xsd">
					<WorkBreakdownStructures>
					   <WorkBreakdownStructure Project="' . $projectCode . '">
						   <Deliverable>
							   <Description>Locatie</Description>
							   <Activity >
									<Description>' . $location . '</Description>
							   </Activity>
						   </Deliverable>
					   </WorkBreakdownStructure>
					</WorkBreakdownStructures>
				</eExact>';

		$wbs     = new ProjectWBSByProject($this->connection);
		$results = $this->connection->get($wbs->url() . "?projectId=guid'" . $projectGuid . "'");
		if (count($results) > 0) {
			return;
		}

		$result = $this->connection->upload('WorkBreakdownStructures', $xml);
	}
```