### PR TITLE
update self with static object initiator

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -160,7 +160,7 @@ trait Findable
         }
         $collection = [];
         foreach ($result as $r) {
-            $collection[] = new self($this->connection(), $r);
+            $collection[] = new static($this->connection(), $r);
         }
 
         return $collection;


### PR DESCRIPTION
using the static keyword allows to override properties in child classes.

example:
I want to use the sync api. So i create a child class SyncGLAccount.
I can change the endpoint but i also need to change the fillable with the "Timestamp" field.
Using "new self" ingores the child fillable property but always takes the fillable property of the highest parent class.
using "new static" solves this.