### PR TITLE
Create new classes with static instead of self

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -38,7 +38,7 @@ trait Findable
 
         $result = isset($records[0]) ? $records[0] : [];
 
-        return new self($this->connection(), $result);
+        return new static($this->connection(), $result);
     }
 
     public function findWithSelect($id, $select = '')
@@ -49,7 +49,7 @@ trait Findable
             '$select' => $select,
         ]);
 
-        return new self($this->connection(), $result);
+        return new static($this->connection(), $result);
     }
 
     /**
@@ -160,7 +160,7 @@ trait Findable
         }
         $collection = [];
         foreach ($result as $r) {
-            $collection[] = new self($this->connection(), $r);
+            $collection[] = new static($this->connection(), $r);
         }
 
         return $collection;


### PR DESCRIPTION
When used as `new self(...)` this would create the class in which it was called, `new static(...)` would create the dynamic class.

Solution for the problem mentioned in #436.