### PR TITLE
Update Guzzle to 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ language: php
 dist: trusty
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "php": ">=7.2.0",
+        "guzzlehttp/guzzle": "~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "guzzlehttp/guzzle": "~7.0"
+        "guzzlehttp/guzzle": "~6.0|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite>
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <testsuites>
+    <testsuite name="Application Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
 </phpunit>


### PR DESCRIPTION
Adresses #435 

Guzzle 7.0 has become standard now for some packages such as [laravel 8.0](https://github.com/laravel/laravel/blob/ca30159cabe05675fa268f49acdf93ef12480b01/composer.json#L14).

We cannot upgrade to laravel `8.0` until all packages have a guzzle minimum of `7.0`.

This PR bumps guzzle to version `7.0` which has a minimum php version of `7.2`.
Also bumps PHPUnit to `8.5`.

Also drops supports for outdated PHP versions which should make this repo easier to maintain in the future.

A new `MAJOR` release is needed for this one as it is a MAJOR php version change.