### PR TITLE
Add a callback to be able to catch refreshes from other threads

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -491,7 +491,7 @@ class Connection
 
             if (is_callable($this->refreshAccessTokenCallback)) {
                 call_user_func($this->refreshAccessTokenCallback, $this);
-                if (!$this->tokenHasExpired()) {
+                if (! $this->tokenHasExpired()) {
                     // the refreshed token has not expired, so we are fine to keep using it
                     return;
                 }


### PR DESCRIPTION
We are working with a distributed application, where we have a shared credential in a database. The issue we are having now is that one thread is able to refresh the token, but this is not reflected in the token that the other threads use. This will cause the error with Exact saying the refresh token is already used by another thread.

Hence I've added a callback that you can call to refresh the token just before its being used and checked.

I've added it in two places to prevent a race condition where two threads nearly end up in the same code at the same time (to acquire access token)

Here is some example code.

        $connection = new Connection();
        $connection->setRedirectUrl(\Yii::$app->params['exact_'.strtolower($model->meta_tenant_country).'_redirect_url']);
        $connection->setExactClientId(\Yii::$app->params['exact_'.strtolower($model->meta_tenant_country).'_client_id']);
        $connection->setExactClientSecret(\Yii::$app->params['exact_'.strtolower($model->meta_tenant_country).'_client_secret']);
        $connection->setBaseUrl('https://start.exactonline.' . strtolower($model->meta_tenant_country));
        $connection->setAccessToken(json_decode($model->getAuthValue('exact_access'), true));
        $connection->setRefreshToken($model->getAuthValue('exact_refresh'));
        $connection->setTokenExpires($model->getAuthValue('exact_expires'));
        $connection->setAcquireAccessTokenLockCallback(function () use ($model) {
            return \Yii::$app->mutex->acquire('credential_refresh_' . $model->credential_id, 60);
        });
        $connection->setAcquireAccessTokenUnlockCallback(function () use ($model) {
            return \Yii::$app->mutex->release('credential_refresh_' . $model->credential_id);
        });
        $connection->setTokenUpdateCallback(function ($connection) use ($model) {
            $model->refresh();
            $model->setAuthValue('exact_access', json_encode($connection->getAccessToken()));
            $model->setAuthValue('exact_refresh', $connection->getRefreshToken());
            $model->setAuthValue('exact_expires', $connection->getTokenExpires() - 60);
            $model->save(false);
        });
        $connection->setTokenRefreshCallback(function ($connection) use ($model) {
            $model->refresh();
            $connection->setAccessToken(json_decode($model->getAuthValue('exact_access'), true));
            $connection->setRefreshToken($model->getAuthValue('exact_refresh'));
            $connection->setTokenExpires($model->getAuthValue('exact_expires'));
        });
        // connect to it
        $connection->connect();

After this its pretty much waterproof 👍 