### PR TITLE
Add Reason for 403 messages

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -654,6 +654,10 @@ class Connection
             $errorMessage = $responseBody;
         }
 
+        if ($reason = $response->getHeaderLine('Reason')) {
+            $errorMessage .= " (Reason: {$reason})";
+        }
+
         throw new ApiException('Error ' . $response->getStatusCode() . ': ' . $errorMessage, $response->getStatusCode(), $e);
     }
 


### PR DESCRIPTION
Adds the Reason headers as described by the docs

```
For example, when you don't have the right to create an invoice but try to create one through the API, you will receive a 403 Forbidden error.

When applicable, an extra header "reason" will display to provide more information about the error. Some possible values for this header are:

BlockedUser
The user has been marked as blocked and cannot access any data.
InactiveUser
The user is no longer active in Exact Online.
BlockedCustomer
The customer has been marked as blocked and cannot access any data.
LicenseExpired
The license of the customer has expired in Exact Online.
DivisionBlocked
The company has been marked as blocked and cannot be accessed.
NoDivisionAccess
The user does not have access to the requested division.
```
Fixes https://github.com/picqer/exact-php-client/issues/447