### PR TITLE
Updates to rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ $connection->getDailyLimitRemaining(); // Retrieve the remaining amount of API c
 $connection->getDailyLimitReset(); // Retrieve the timestamp for when the limit will reset
 $connection->getMinutelyLimit(); // Retrieve your limit per minute
 $connection->getMinutelyLimitRemaining(); // Retrieve the amount of API calls remaining for this minute
+$connection->getMinutelyLimitReset(); // Retrieve the timestamp for when the minutely limit will reset
 ```
+_Do note that when you have no more minutely calls available, Exact only sends the Minutely Limit headers. So in that case, the Daily Limit headers will remain 0 untill the minutely reset rolls over._
+
 
 ### Use the library to do stuff (examples)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $connection->getMinutelyLimit(); // Retrieve your limit per minute
 $connection->getMinutelyLimitRemaining(); // Retrieve the amount of API calls remaining for this minute
 $connection->getMinutelyLimitReset(); // Retrieve the timestamp for when the minutely limit will reset
 ```
-_Do note that when you have no more minutely calls available, Exact only sends the Minutely Limit headers. So in that case, the Daily Limit headers will remain 0 untill the minutely reset rolls over._
+_Do note when you have no more minutely calls available, Exact only sends the Minutely Limit headers. So in that case, the Daily Limit headers will remain 0 until the minutely reset rolls over._
 
 
 ### Use the library to do stuff (examples)

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -413,11 +413,11 @@ class Connection
     private function parseResponse(Response $response, $returnSingleIfPossible = true)
     {
         try {
+            $this->extractRateLimits($response);
+            
             if ($response->getStatusCode() === 204) {
                 return [];
             }
-
-            $this->extractRateLimits($response);
 
             Psr7\rewind_body($response);
             $json = json_decode($response->getBody()->getContents(), true);

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -129,6 +129,11 @@ class Connection
      * @var int|null
      */
     protected $minutelyLimitRemaining;
+    
+    /**
+     * @var int|null
+     */
+    protected $minutelyLimitReset;
 
     /**
      * @return Client
@@ -700,6 +705,13 @@ class Connection
     {
         return $this->minutelyLimitRemaining;
     }
+    /**
+     * @return int|null The time at which the minutely rate limit window resets in UTC epoch milliseconds
+     */
+    public function getMinutelyLimitReset()
+    {
+        return $this->minutelyLimitReset;
+    }
 
     /**
      * @return string
@@ -768,5 +780,6 @@ class Connection
 
         $this->minutelyLimit = (int) $response->getHeaderLine('X-RateLimit-Minutely-Limit');
         $this->minutelyLimitRemaining = (int) $response->getHeaderLine('X-RateLimit-Minutely-Remaining');
+        $this->minutelyLimitReset = (int) $response->getHeaderLine('X-RateLimit-Minutely-Reset');
     }
 }

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -129,7 +129,7 @@ class Connection
      * @var int|null
      */
     protected $minutelyLimitRemaining;
-    
+
     /**
      * @var int|null
      */
@@ -414,7 +414,7 @@ class Connection
     {
         try {
             $this->extractRateLimits($response);
-            
+
             if ($response->getStatusCode() === 204) {
                 return [];
             }
@@ -705,6 +705,7 @@ class Connection
     {
         return $this->minutelyLimitRemaining;
     }
+
     /**
      * @return int|null The time at which the minutely rate limit window resets in UTC epoch milliseconds
      */


### PR DESCRIPTION
This pull request fixes the extraction of rate limits, which weren't set when updating resources (PUT 204 response).
There is also an extra method included to add the minutely reset timestamp.

![image](https://user-images.githubusercontent.com/7084691/102778009-0e5a0980-4392-11eb-9e17-d91d8c0eb6a6.png)
