### PR TITLE
Findable filter does not require a filter 

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -91,9 +91,11 @@ trait Findable
             $this->connection()->setDivision($divisionId[1]); // Fix division
         }
 
-        $request = [
-            '$filter' => $filter,
-        ];
+        $request = [];
+        if ( !empty($filter)) {
+            $request ['$filter'] = $filter;
+        }
+
         if (strlen($expand) > 0) {
             $request['$expand'] = $expand;
         }

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -92,8 +92,8 @@ trait Findable
         }
 
         $request = [];
-        if ( !empty($filter)) {
-            $request ['$filter'] = $filter;
+        if (! empty($filter)) {
+            $request['$filter'] = $filter;
         }
 
         if (strlen($expand) > 0) {


### PR DESCRIPTION
For (bulk?) queries a filter is not required and an empty filter returns "Error 400: This $filter parameter is not supported for this resource"

