### PR TITLE
Change permission schema and handle temporary 503's from Exact

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -536,7 +536,7 @@ class Connection
                 throw new ApiException('Could not acquire tokens, json decode failed. Got response: ' . $response->getBody()->getContents());
             }
         } catch (BadResponseException $ex) {
-            if ((int)$ex->getResponse()->getStatusCode() === 503) {
+            if ((int) $ex->getResponse()->getStatusCode() === 503) {
                 // wait for 30 seconds and try again, these 503's are temporary at exact due to a reboot of server of some kind
                 sleep(30);
                 // unlock it if need be

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -536,7 +536,18 @@ class Connection
                 throw new ApiException('Could not acquire tokens, json decode failed. Got response: ' . $response->getBody()->getContents());
             }
         } catch (BadResponseException $ex) {
-            throw new ApiException('Could not acquire or refresh tokens [http ' . $ex->getResponse()->getStatusCode() . ']', 0, $ex);
+            if ((int)$ex->getResponse()->getStatusCode() === 503) {
+                // wait for 30 seconds and try again, these 503's are temporary at exact due to a reboot of server of some kind
+                sleep(30);
+                // unlock it if need be
+                if (is_callable($this->acquireAccessTokenUnlockCallback)) {
+                    call_user_func($this->acquireAccessTokenUnlockCallback, $this);
+                }
+                // rerun
+                $this->acquireAccessToken();
+            } else {
+                throw new ApiException('Could not acquire or refresh tokens [http ' . $ex->getResponse()->getStatusCode() . ']', 0, $ex);
+            }
         } finally {
             if (is_callable($this->acquireAccessTokenUnlockCallback)) {
                 call_user_func($this->acquireAccessTokenUnlockCallback, $this);

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -73,7 +73,7 @@ class Connection
     /**
      * @var mixed
      */
-    private $division;
+    protected $division;
 
     /**
      * @var Client|null
@@ -451,7 +451,7 @@ class Connection
     /**
      * @return mixed
      */
-    private function getCurrentDivisionNumber()
+    protected function getCurrentDivisionNumber()
     {
         if (empty($this->division)) {
             $me = new Me($this);
@@ -580,7 +580,7 @@ class Connection
         return ($this->tokenExpires - 60) < time();
     }
 
-    private function formatUrl($endPoint, $includeDivision = true, $formatNextUrl = false)
+    protected function formatUrl($endPoint, $includeDivision = true, $formatNextUrl = false)
     {
         if ($formatNextUrl) {
             return $endPoint;

--- a/src/Picqer/Financials/Exact/SystemDivisionAll.php
+++ b/src/Picqer/Financials/Exact/SystemDivisionAll.php
@@ -3,9 +3,8 @@
 namespace Picqer\Financials\Exact;
 
 /**
- * Class SystemDivisionAll
+ * Class SystemDivisionAll.
  *
- * @package Picqer\Financials\Exact
  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SystemSystemAllDivisions
  *
  * @property int $Code Primary key

--- a/src/Picqer/Financials/Exact/SystemDivisionAll.php
+++ b/src/Picqer/Financials/Exact/SystemDivisionAll.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Picqer\Financials\Exact;
+
+/**
+ * Class SystemDivisionAll
+ *
+ * @package Picqer\Financials\Exact
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SystemSystemAllDivisions
+ *
+ * @property int $Code Primary key
+ * @property string $AddressLine1 Address line 1
+ * @property string $AddressLine2 Address line 2
+ * @property string $AddressLine3 Address line 3
+ * @property int $BlockingStatus Values: 0 = Not blocked, 1 = Backup/restore, 2 = Conversion busy, 3 = Conversion shadow, 4 = Conversion waiting, 5 = Copy data waiting, 6 = Copy data busy
+ * @property string $BusinessTypeCode Business type code
+ * @property string $BusinessTypeDescription Business type description
+ * @property string $ChamberOfCommerceEstablishment Chamber of commerce establishment
+ * @property string $ChamberOfCommerceNumber Chamber of commerce number
+ * @property string $City City
+ * @property exact.web.api.models.hrm.divisionclass $Class_01 First division classification. User should have access rights to view division classifications.
+ * @property exact.web.api.models.hrm.divisionclass $Class_02 Second division classification. User should have access rights to view division classifications.
+ * @property exact.web.api.models.hrm.divisionclass $Class_03 Third division classification. User should have access rights to view division classifications.
+ * @property exact.web.api.models.hrm.divisionclass $Class_04 Fourth division classification. User should have access rights to view division classifications.
+ * @property exact.web.api.models.hrm.divisionclass $Class_05 Fifth division classification. User should have access rights to view division classifications.
+ * @property string $CompanySizeCode Company size code
+ * @property string $CompanySizeDescription Company size description
+ * @property string $Country Country of the division. Is used for determination of legislation
+ * @property string $Created Creation date
+ * @property string $Creator User ID of creator
+ * @property string $CreatorFullName Name of the creator
+ * @property string $Currency Default currency
+ * @property bool $Current True when this division is most recently used by the API
+ * @property string $Customer Owner account of the division
+ * @property string $CustomerCode Owner account code of the division
+ * @property string $CustomerName Owner account name of the division
+ * @property string $DatevAccountantNumber Accountant number DATEV (Germany)
+ * @property string $DatevClientNumber Client number DATEV (Germany)
+ * @property string $Description Description
+ * @property string $DivisionMoveDate Date when the division was moved. Please resync all data when this value changes because value of Timestamp is regenerated.
+ * @property string $Email Email address
+ * @property string $Fax Fax number
+ * @property int64 $Hid Company number that is assigned by the customer
+ * @property bool $IsDossierDivision True if the division is a dossier division
+ * @property bool $IsMainDivision True if the division is the main division
+ * @property string $Legislation Legislation
+ * @property string $Modified Last modified date
+ * @property string $Modifier User ID of modifier
+ * @property string $ModifierFullName Name of the last modifier
+ * @property string $OBNumber The soletrader VAT number used for offical returns to tax authority
+ * @property string $Phone Phone number
+ * @property string $Postcode Postcode
+ * @property string $SbiCode SBI code
+ * @property string $SbiDescription SBI description
+ * @property string $SectorCode Sector code
+ * @property string $SectorDescription Sector description
+ * @property float $ShareCapital the part of the capital of a company that comes from the issue of shares (France)
+ * @property string $SiretNumber An INSEE code which allows the geographic identification of the company. (France)
+ * @property string $StartDate Date on which the division becomes active
+ * @property string $State State/Province code
+ * @property int $Status Follow the Division Status 0 for Inactive, 1 for Active and 2 for Archived Divisions
+ * @property string $SubsectorCode Subsector code
+ * @property string $SubsectorDescription Subsector description
+ * @property string $TaxOfficeNumber Number of your local tax authority (Germany)
+ * @property string $TaxReferenceNumber Local tax reference number (Germany)
+ * @property string $TemplateCode Division template code
+ * @property string $VATNumber The number under which the account is known at the Value Added Tax collection agency
+ * @property string $Website Customer value, hyperlink to external website
+ */
+class SystemDivisionAll extends Model
+{
+    use Query\Findable;
+    use Persistance\Storable;
+
+    protected $primaryKey = 'Code';
+
+    protected $fillable = [
+        'Code',
+        'AddressLine1',
+        'AddressLine2',
+        'AddressLine3',
+        'BlockingStatus',
+        'BusinessTypeCode',
+        'BusinessTypeDescription',
+        'ChamberOfCommerceEstablishment',
+        'ChamberOfCommerceNumber',
+        'City',
+        'Class_01',
+        'Class_02',
+        'Class_03',
+        'Class_04',
+        'Class_05',
+        'CompanySizeCode',
+        'CompanySizeDescription',
+        'Country',
+        'Created',
+        'Creator',
+        'CreatorFullName',
+        'Currency',
+        'Current',
+        'Customer',
+        'CustomerCode',
+        'CustomerName',
+        'DatevAccountantNumber',
+        'DatevClientNumber',
+        'Description',
+        'DivisionMoveDate',
+        'Email',
+        'Fax',
+        'Hid',
+        'IsDossierDivision',
+        'IsMainDivision',
+        'Legislation',
+        'Modified',
+        'Modifier',
+        'ModifierFullName',
+        'OBNumber',
+        'Phone',
+        'Postcode',
+        'SbiCode',
+        'SbiDescription',
+        'SectorCode',
+        'SectorDescription',
+        'ShareCapital',
+        'SiretNumber',
+        'StartDate',
+        'State',
+        'Status',
+        'SubsectorCode',
+        'SubsectorDescription',
+        'TaxOfficeNumber',
+        'TaxReferenceNumber',
+        'TemplateCode',
+        'VATNumber',
+        'Website',
+    ];
+
+    protected $url = 'system/AllDivisions';
+}


### PR DESCRIPTION
Exact Online sometimes gives a 503 when refreshing the access token. If that specific code happens we need to retry because that error is temporary (it happens when Exact scales in or out). Also it makes sense for the private attributes in this class to be protected so you can extend the connection and add some own logic too it (for instance we've extended it to post XML files).

Next to that I added the SystemDivisionAll endpoint which returns you all divisions also the ones you do not have access to. 