### PR TITLE
Fix resources that require guid/primary key in an explicit GET parameter

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -235,7 +235,7 @@ class Connection
 
         // Create param string
         if (! empty($params)) {
-            $endpoint .= strpos($endpoint, '?') === false ? "?" : "&";
+            $endpoint .= strpos($endpoint, '?') === false ? '?' : '&';
             $endpoint .= http_build_query($params);
         }
 

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -235,7 +235,8 @@ class Connection
 
         // Create param string
         if (! empty($params)) {
-            $endpoint .= '?' . http_build_query($params);
+            $endpoint .= strpos($endpoint, '?')===false? "?" : "&";
+            $endpoint .= http_build_query($params);
         }
 
         // Create the request

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -235,7 +235,7 @@ class Connection
 
         // Create param string
         if (! empty($params)) {
-            $endpoint .= strpos($endpoint, '?')===false? "?" : "&";
+            $endpoint .= strpos($endpoint, '?') === false ? "?" : "&";
             $endpoint .= http_build_query($params);
         }
 

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -73,7 +73,7 @@ abstract class Model implements \JsonSerializable
         if (isset($id)) {
             return str_replace('{Edm.Guid}', "guid'" . $id . "'", $this->url);
         }
-        
+
         return $this->url;
     }
 

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -71,7 +71,7 @@ abstract class Model implements \JsonSerializable
     public function url($id = null)
     {
         if (isset($id)) {
-            return str_replace("{Edm.Guid}", "guid'" . $id . "'", $this->url);
+            return str_replace('{Edm.Guid}', "guid'" . $id . "'", $this->url);
         }
         return $this->url;
     }

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -73,6 +73,7 @@ abstract class Model implements \JsonSerializable
         if (isset($id)) {
             return str_replace('{Edm.Guid}', "guid'" . $id . "'", $this->url);
         }
+        
         return $this->url;
     }
 

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -70,7 +70,7 @@ abstract class Model implements \JsonSerializable
      */
     public function url()
     {
-        return $this->url;
+        return str_replace("{Edm.Guid}", "guid'".$this->primaryKeyContent()."'", $this->url);
     }
 
     /**

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -68,9 +68,12 @@ abstract class Model implements \JsonSerializable
      *
      * @return string
      */
-    public function url()
+    public function url($id=null)
     {
-        return str_replace("{Edm.Guid}", "guid'".$this->primaryKeyContent()."'", $this->url);
+        if (isset($id)) {
+            return str_replace("{Edm.Guid}", "guid'".$id."'", $this->url);
+        }
+        return $this->url;
     }
 
     /**

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -68,10 +68,10 @@ abstract class Model implements \JsonSerializable
      *
      * @return string
      */
-    public function url($id=null)
+    public function url($id = null)
     {
         if (isset($id)) {
-            return str_replace("{Edm.Guid}", "guid'".$id."'", $this->url);
+            return str_replace("{Edm.Guid}", "guid'" . $id . "'", $this->url);
         }
         return $this->url;
     }

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -31,7 +31,7 @@ trait Findable
             $filter = $this->primaryKey() . " eq $id";
         }
 
-        $records = $this->connection()->get($this->url(), [
+        $records = $this->connection()->get($this->url($id), [
             '$filter' => $filter,
             '$top'    => 1, // The result will always be 1 but on some entities Exact gives an error without it.
         ]);
@@ -44,7 +44,7 @@ trait Findable
     public function findWithSelect($id, $select = '')
     {
         //eg: $oAccounts->findWithSelect('5b7f4515-b7a0-4839-ac69-574968677d96', 'Code, Name');
-        $result = $this->connection()->get($this->url(), [
+        $result = $this->connection()->get($this->url($id), [
             '$filter' => $this->primaryKey() . " eq guid'$id'",
             '$select' => $select,
         ]);


### PR DESCRIPTION
Some resources require the GUID of the resource explicitly in the URL of the resource. 
Current code holds placeholders for this ID, but these placeholders are never replaced by the actual ID.
This fixes that

This fixes issue #424 and is a more generic fix to the issue than proposed fix in PR #467 which focusses only on a single entity,  since there are 30 more.

Some of those entities also require other paramaters, such as ReceivablesListByAccountAndAgeGroup, which also requires an ageGroup parameter. This PR does not fix those.