### PR TITLE
Add callbacks before and after requests

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -101,6 +101,16 @@ class Connection
     private $refreshAccessTokenCallback;
 
     /**
+     * @var callable(Connection, Request)
+     */
+    private $createRequestCallback;
+
+    /**
+     * @var callable(Connection, Response)
+     */
+    private $parseResponseCallback;
+
+    /**
      * @var callable[]
      */
     protected $middleWares = [];
@@ -240,6 +250,10 @@ class Connection
 
         // Create the request
         $request = new Request($method, $endpoint, $headers, $body);
+
+        if (is_callable($this->createRequestCallback)) {
+            call_user_func($this->createRequestCallback, $this, $request);
+        }
 
         return $request;
     }
@@ -418,6 +432,10 @@ class Connection
     private function parseResponse(Response $response, $returnSingleIfPossible = true)
     {
         try {
+            if (is_callable($this->parseResponseCallback)) {
+                call_user_func($this->parseResponseCallback, $this, $response);
+            }
+
             $this->extractRateLimits($response);
 
             if ($response->getStatusCode() === 204) {
@@ -643,6 +661,22 @@ class Connection
     public function setTokenUpdateCallback($callback)
     {
         $this->tokenUpdateCallback = $callback;
+    }
+
+    /**
+     * @param callable(Connection, Request) $callback
+     */
+    public function setCreateRequestCallback($callback)
+    {
+        $this->createRequestCallback = $callback;
+    }
+
+    /**
+     * @param callable(Connection, Response) $callback
+     */
+    public function setParseResponseCallback($callback)
+    {
+        $this->parseResponseCallback = $callback;
     }
 
     /**


### PR DESCRIPTION
Due to the upcoming new API limits in Exact I thought it might be useful to have some way of logging all API calls made to Exact. The best way to do that in my opinion was to make before/after callbacks, so everyone can implement their own logging. Or this can be used for a logging of all errors etc.

Adding these functions should technically be seen as a major version increase, as it could be a possible backwards incompatible change. If anyone extended the Connection class, and added functions with exactly the same name, this change might break their classes. Unlikely, but it can happen.