### PR TITLE
Fix for #481

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -195,14 +195,23 @@ class Connection
             $this->redirectForAuthorization();
         }
 
-        // If access token is not set or token has expired, acquire new token
-        if (empty($this->accessToken) || $this->tokenHasExpired()) {
-            $this->acquireAccessToken();
-        }
+        $this->checkOrAcquireAccessToken();
 
         $client = $this->client();
 
         return $client;
+    }
+
+    /**
+     * Checks whether the access token is still valid.
+     *
+     * @throws \Picqer\Financials\Exact\ApiException
+     */
+    public function checkOrAcquireAccessToken() {
+        // If access token is not set or token has expired, acquire new token
+        if (empty($this->accessToken) || $this->tokenHasExpired()) {
+            $this->acquireAccessToken();
+        }
     }
 
     /**
@@ -259,6 +268,7 @@ class Connection
 
         try {
             $request = $this->createRequest('GET', $url, null, $params, $headers);
+            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response, $url != $this->nextUrl);
@@ -281,6 +291,7 @@ class Connection
 
         try {
             $request = $this->createRequest('POST', $url, $body);
+            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response);
@@ -303,6 +314,7 @@ class Connection
 
         try {
             $request = $this->createRequest('PUT', $url, $body);
+            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response);
@@ -324,6 +336,7 @@ class Connection
 
         try {
             $request = $this->createRequest('DELETE', $url);
+            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response);

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -207,7 +207,8 @@ class Connection
      *
      * @throws \Picqer\Financials\Exact\ApiException
      */
-    public function checkOrAcquireAccessToken() {
+    public function checkOrAcquireAccessToken()
+    {
         // If access token is not set or token has expired, acquire new token
         if (empty($this->accessToken) || $this->tokenHasExpired()) {
             $this->acquireAccessToken();


### PR DESCRIPTION
This PR make sure the following happens:

When a `get`, `post`, `put` or  `delete` function call is made it checks whether the access token is still valid.

See for a more detailed description #481 