### PR TITLE
Replace deprecated rewind_body with Message::rewindBody

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -439,7 +439,7 @@ class Connection
                 return [];
             }
 
-            Psr7\rewind_body($response);
+            Psr7\Message::rewindBody($response);
             $json = json_decode($response->getBody()->getContents(), true);
             if (false === is_array($json)) {
                 throw new ApiException('Json decode failed. Got response: ' . $response->getBody()->getContents());
@@ -536,7 +536,7 @@ class Connection
 
             $response = $this->client()->post($this->getTokenUrl(), $body);
 
-            Psr7\rewind_body($response);
+            Psr7\Message::rewindBody($response);
             $body = json_decode($response->getBody()->getContents(), true);
 
             if (json_last_error() === JSON_ERROR_NONE) {
@@ -685,7 +685,7 @@ class Connection
 
         $this->extractRateLimits($response);
 
-        Psr7\rewind_body($response);
+        Psr7\Message::rewindBody($response);
         $responseBody = $response->getBody()->getContents();
         $decodedResponseBody = json_decode($responseBody, true);
 


### PR DESCRIPTION
`rewind_body` will be removed in `guzzlehttp/psr7:2.0`. Usage of `Message::rewindBody` is adviced instead.