### PR TITLE
Applying psalm and phpstan suggestions

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -179,9 +179,9 @@ class Connection
     }
 
     /**
-     * Insert a Middleware for the Guzzle Client.
+     * Insert a Middleware for the Guzzle-Client.
      *
-     * @param $middleWare
+     * @param callable $middleWare
      */
     public function insertMiddleWare($middleWare)
     {
@@ -310,7 +310,7 @@ class Connection
     }
 
     /**
-     * @param string $url
+     * @param string $topic
      * @param mixed  $body
      *
      * @throws ApiException

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -514,7 +514,7 @@ class Connection
             }
 
             $answer = [];
-            Psr7\rewind_body($response);
+            Psr7\Message::rewindBody($response);
             $simpleXml = new \SimpleXMLElement($response->getBody()->getContents());
 
             foreach ($simpleXml->Messages as $message) {
@@ -632,7 +632,7 @@ class Connection
             throw new \InvalidArgumentException('Function requires a numeric expires value');
         }
 
-        return time() + $expiresIn;
+        return time() + (int) $expiresIn;
     }
 
     /**

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -211,7 +211,7 @@ abstract class Model implements \JsonSerializable
     /**
      * Refresh deferred item by clearing and then lazy loading it.
      *
-     * @param $key
+     * @param mixed $key
      *
      * @return mixed
      */
@@ -249,7 +249,7 @@ abstract class Model implements \JsonSerializable
         if ($withDeferred) {
             foreach ($this->deferred as $attribute => $collection) {
                 if (empty($collection)) {
-                    continue; // Leave orriginal array with __deferred key
+                    continue; // Leave original array with __deferred key
                 }
 
                 $attributes[$attribute] = [];

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -286,7 +286,7 @@ abstract class Model implements \JsonSerializable
      *
      * @param string $action
      *
-     * @return bool
+     * @return bool|null
      */
     public function userHasRights($action = 'GET')
     {

--- a/src/Picqer/Financials/Exact/Persistance/Storable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Storable.php
@@ -15,7 +15,7 @@ trait Storable
     /**
      * @param array $attributes
      */
-    abstract public function fill(array $attributes);
+    abstract protected function fill(array $attributes);
 
     /**
      * @param int  $options

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -58,7 +58,7 @@ trait Findable
      * @param string $code the value to search for
      * @param string $key  the key being searched (defaults to 'Code')
      *
-     * @return string (guid)
+     * @return string|void (guid)
      */
     public function findId($code, $key = 'Code')
     {

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -11,7 +11,7 @@ trait Findable
      */
     abstract public function connection();
 
-    abstract public function isFillable($key);
+    abstract protected function isFillable($key);
 
     /**
      * @return string


### PR DESCRIPTION
Using Psalm (errorLevel=4) I was able to resolve the following issues:
- Replaces a rewind_body with Message::rewindBody similar to #491 
- Ensures timestamp calculation is done using a number
- Corrects return types based on code
- Correct function scope in traits based on implementation

Using PHPStan (level: 4) I was able to resolve the following issues:
- Correct @param phpdoc
- Correct some typos
- Add missing return type based on implementation