### PR TITLE
removed redundant checkOrAcquireAccessToken() 

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -227,8 +227,9 @@ class Connection
      * @param array  $params
      * @param array  $headers
      *
-     * @return Request
      * @throws ApiException
+     *
+     * @return Request
      */
     private function createRequest($method, $endpoint, $body = null, array $params = [], array $headers = [])
     {

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -228,6 +228,7 @@ class Connection
      * @param array  $headers
      *
      * @return Request
+     * @throws ApiException
      */
     private function createRequest($method, $endpoint, $body = null, array $params = [], array $headers = [])
     {
@@ -238,10 +239,7 @@ class Connection
             'Prefer'       => 'return=representation',
         ]);
 
-        // If access token is not set or token has expired, acquire new token
-        if (empty($this->accessToken) || $this->tokenHasExpired()) {
-            $this->acquireAccessToken();
-        }
+        $this->checkOrAcquireAccessToken();
 
         // If we have a token, sign the request
         if (! $this->needsAuthentication() && ! empty($this->accessToken)) {
@@ -276,7 +274,6 @@ class Connection
 
         try {
             $request = $this->createRequest('GET', $url, null, $params, $headers);
-            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response, $url != $this->nextUrl);
@@ -300,7 +297,6 @@ class Connection
 
         try {
             $request = $this->createRequest('POST', $url, $body);
-            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response);
@@ -346,7 +342,6 @@ class Connection
 
         try {
             $request = $this->createRequest('PUT', $url, $body);
-            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response);
@@ -369,7 +364,6 @@ class Connection
 
         try {
             $request = $this->createRequest('DELETE', $url);
-            $this->checkOrAcquireAccessToken();
             $response = $this->client()->send($request);
 
             return $this->parseResponse($response);


### PR DESCRIPTION
This pull request removes the redundant checkOrAcquireAccessToken()  calls in the get, post, put and delete requests. The same functionality was already being called in createRequest, which all the requests call upon. 