### PR TITLE
Feature/state parameter support

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -392,6 +392,7 @@ class Connection
             'client_id'     => $this->exactClientId,
             'redirect_uri'  => $this->redirectUrl,
             'response_type' => 'code',
+            'state' => $this->state,
         ]);
     }
 

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -71,6 +71,11 @@ class Connection
     private $redirectUrl;
 
     /**
+     * @var string
+     */
+    private $state = null;
+
+    /**
      * @var mixed
      */
     private $division;
@@ -443,6 +448,14 @@ class Connection
     public function setRedirectUrl($redirectUrl)
     {
         $this->redirectUrl = $redirectUrl;
+    }
+
+    /**
+     * @param string $state
+     */
+    public function setState(string $state)
+    {
+        $this->state = $state;
     }
 
     /**

--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -392,7 +392,7 @@ class Connection
             'client_id'     => $this->exactClientId,
             'redirect_uri'  => $this->redirectUrl,
             'response_type' => 'code',
-            'state' => $this->state,
+            'state'         => $this->state,
         ]);
     }
 


### PR DESCRIPTION
This PR adds support for using Exacts optional state parameter in the authorization request. For a while, Exact has tightened up the validation on the redirect URL, requiring a 1 to 1 match. As a result, it is no longer possible to place a "state" parameter as a query parameter after the redirect URL. Exact, on the other hand, does offer an option for a state parameter in the entire authorization request as described in [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.1).

If the state parameter is not supplied to the Connection, no new query parameter will be added to the request. As a result, this PR will not bring any breaking changes.