### PR TITLE
Fix query string 

### DIFF
--- a/src/Picqer/Financials/Exact/AccountDocument.php
+++ b/src/Picqer/Financials/Exact/AccountDocument.php
@@ -73,5 +73,5 @@ class AccountDocument extends Model
         'TypeDescription',
     ];
 
-    protected $url = 'read/crm/AccountDocuments?accountId={Edm.Guid}&searchText={Edm.String}&useFullTextSearch={Edm.Boolean}';
+    protected $url = 'read/crm/AccountDocuments';
 }

--- a/src/Picqer/Financials/Exact/AccountDocumentCount.php
+++ b/src/Picqer/Financials/Exact/AccountDocumentCount.php
@@ -15,5 +15,5 @@ class AccountDocumentCount extends Model
     protected $fillable = [
     ];
 
-    protected $url = 'read/crm/AccountDocumentsCount?accountId={Edm.Guid}&searchText={Edm.String}&useFullTextSearch={Edm.Boolean}';
+    protected $url = 'read/crm/AccountDocumentsCount';
 }

--- a/src/Picqer/Financials/Exact/AccountDocumentFolder.php
+++ b/src/Picqer/Financials/Exact/AccountDocumentFolder.php
@@ -45,5 +45,5 @@ class AccountDocumentFolder extends Model
         'SharePointID',
     ];
 
-    protected $url = 'read/crm/AccountDocumentFolders?accountId={Edm.Guid}';
+    protected $url = 'read/crm/AccountDocumentFolders';
 }

--- a/src/Picqer/Financials/Exact/AgingOverviewByAccount.php
+++ b/src/Picqer/Financials/Exact/AgingOverviewByAccount.php
@@ -27,5 +27,5 @@ class AgingOverviewByAccount extends Model
         'CurrencyCode',
     ];
 
-    protected $url = 'read/financial/AgingOverviewByAccount?accountId={Edm.Guid}';
+    protected $url = 'read/financial/AgingOverviewByAccount';
 }

--- a/src/Picqer/Financials/Exact/AgingPayablesListByAgeGroup.php
+++ b/src/Picqer/Financials/Exact/AgingPayablesListByAgeGroup.php
@@ -51,5 +51,5 @@ class AgingPayablesListByAgeGroup extends Model
         'TotalAmount',
     ];
 
-    protected $url = 'read/financial/AgingPayablesListByAgeGroup?ageGroup={Edm.Int32}';
+    protected $url = 'read/financial/AgingPayablesListByAgeGroup';
 }

--- a/src/Picqer/Financials/Exact/AgingReceivablesListByAgeGroup.php
+++ b/src/Picqer/Financials/Exact/AgingReceivablesListByAgeGroup.php
@@ -51,5 +51,5 @@ class AgingReceivablesListByAgeGroup extends Model
         'TotalAmount',
     ];
 
-    protected $url = 'read/financial/AgingReceivablesListByAgeGroup?ageGroup={Edm.Int32}';
+    protected $url = 'read/financial/AgingReceivablesListByAgeGroup';
 }

--- a/src/Picqer/Financials/Exact/CostEntryExpensesByProject.php
+++ b/src/Picqer/Financials/Exact/CostEntryExpensesByProject.php
@@ -21,5 +21,5 @@ class CostEntryExpensesByProject extends Model
         'ParentDescription',
     ];
 
-    protected $url = 'read/project/CostEntryExpensesByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/CostEntryExpensesByProject';
 }

--- a/src/Picqer/Financials/Exact/CostEntryRecentAccountsByProject.php
+++ b/src/Picqer/Financials/Exact/CostEntryRecentAccountsByProject.php
@@ -23,5 +23,5 @@ class CostEntryRecentAccountsByProject extends Model
         'DateLastUsed',
     ];
 
-    protected $url = 'read/project/CostEntryRecentAccountsByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/CostEntryRecentAccountsByProject';
 }

--- a/src/Picqer/Financials/Exact/CostEntryRecentCostTypesByProject.php
+++ b/src/Picqer/Financials/Exact/CostEntryRecentCostTypesByProject.php
@@ -23,5 +23,5 @@ class CostEntryRecentCostTypesByProject extends Model
         'ItemDescription',
     ];
 
-    protected $url = 'read/project/CostEntryRecentCostTypesByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/CostEntryRecentCostTypesByProject';
 }

--- a/src/Picqer/Financials/Exact/CostEntryRecentExpensesByProject.php
+++ b/src/Picqer/Financials/Exact/CostEntryRecentExpensesByProject.php
@@ -23,5 +23,5 @@ class CostEntryRecentExpensesByProject extends Model
         'ParentDescription',
     ];
 
-    protected $url = 'read/project/CostEntryRecentExpensesByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/CostEntryRecentExpensesByProject';
 }

--- a/src/Picqer/Financials/Exact/CostTypesByDate.php
+++ b/src/Picqer/Financials/Exact/CostTypesByDate.php
@@ -21,5 +21,5 @@ class CostTypesByDate extends Model
         'ItemDescription',
     ];
 
-    protected $url = 'read/project/CostTypesByDate?checkDate={Edm.DateTime}';
+    protected $url = 'read/project/CostTypesByDate';
 }

--- a/src/Picqer/Financials/Exact/CostTypesByProjectAndDate.php
+++ b/src/Picqer/Financials/Exact/CostTypesByProjectAndDate.php
@@ -21,5 +21,5 @@ class CostTypesByProjectAndDate extends Model
         'ItemDescription',
     ];
 
-    protected $url = 'read/project/CostTypesByProjectAndDate?projectId={Edm.Guid}&checkDate={Edm.DateTime}';
+    protected $url = 'read/project/CostTypesByProjectAndDate';
 }

--- a/src/Picqer/Financials/Exact/CostsByDate.php
+++ b/src/Picqer/Financials/Exact/CostsByDate.php
@@ -67,5 +67,5 @@ class CostsByDate extends Model
         'WeekNumber',
     ];
 
-    protected $url = 'read/project/CostsByDate?checkDate={Edm.DateTime}';
+    protected $url = 'read/project/CostsByDate';
 }

--- a/src/Picqer/Financials/Exact/CostsById.php
+++ b/src/Picqer/Financials/Exact/CostsById.php
@@ -67,5 +67,5 @@ class CostsById extends Model
         'WeekNumber',
     ];
 
-    protected $url = 'read/project/CostsById?entryId={Edm.Guid}';
+    protected $url = 'read/project/CostsById';
 }

--- a/src/Picqer/Financials/Exact/DefaultAddressForAccount.php
+++ b/src/Picqer/Financials/Exact/DefaultAddressForAccount.php
@@ -121,5 +121,5 @@ class DefaultAddressForAccount extends Model
         'WarehouseDescription',
     ];
 
-    protected $url = 'read/crm/DefaultAddressForAccount?accountId={Edm.Guid}&addressType={Edm.Int32}';
+    protected $url = 'read/crm/DefaultAddressForAccount';
 }

--- a/src/Picqer/Financials/Exact/HourEntryActivitiesByProject.php
+++ b/src/Picqer/Financials/Exact/HourEntryActivitiesByProject.php
@@ -21,5 +21,5 @@ class HourEntryActivitiesByProject extends Model
         'ParentDescription',
     ];
 
-    protected $url = 'read/project/HourEntryActivitiesByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/HourEntryActivitiesByProject';
 }

--- a/src/Picqer/Financials/Exact/HourEntryRecentAccountsByProject.php
+++ b/src/Picqer/Financials/Exact/HourEntryRecentAccountsByProject.php
@@ -23,5 +23,5 @@ class HourEntryRecentAccountsByProject extends Model
         'DateLastUsed',
     ];
 
-    protected $url = 'read/project/HourEntryRecentAccountsByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/HourEntryRecentAccountsByProject';
 }

--- a/src/Picqer/Financials/Exact/HourEntryRecentActivitiesByProject.php
+++ b/src/Picqer/Financials/Exact/HourEntryRecentActivitiesByProject.php
@@ -23,5 +23,5 @@ class HourEntryRecentActivitiesByProject extends Model
         'ParentDescription',
     ];
 
-    protected $url = 'read/project/HourEntryRecentActivitiesByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/HourEntryRecentActivitiesByProject';
 }

--- a/src/Picqer/Financials/Exact/HourEntryRecentHourTypesByProject.php
+++ b/src/Picqer/Financials/Exact/HourEntryRecentHourTypesByProject.php
@@ -23,5 +23,5 @@ class HourEntryRecentHourTypesByProject extends Model
         'ItemDescription',
     ];
 
-    protected $url = 'read/project/HourEntryRecentHourTypesByProject?projectId={Edm.Guid}';
+    protected $url = 'read/project/HourEntryRecentHourTypesByProject';
 }

--- a/src/Picqer/Financials/Exact/HourTypesByDate.php
+++ b/src/Picqer/Financials/Exact/HourTypesByDate.php
@@ -21,5 +21,5 @@ class HourTypesByDate extends Model
         'ItemDescription',
     ];
 
-    protected $url = 'read/project/HourTypesByDate?checkDate={Edm.DateTime}';
+    protected $url = 'read/project/HourTypesByDate';
 }

--- a/src/Picqer/Financials/Exact/HourTypesByProjectAndDate.php
+++ b/src/Picqer/Financials/Exact/HourTypesByProjectAndDate.php
@@ -21,5 +21,5 @@ class HourTypesByProjectAndDate extends Model
         'ItemDescription',
     ];
 
-    protected $url = 'read/project/HourTypesByProjectAndDate?projectId={Edm.Guid}&checkDate={Edm.DateTime}';
+    protected $url = 'read/project/HourTypesByProjectAndDate';
 }

--- a/src/Picqer/Financials/Exact/HoursByDate.php
+++ b/src/Picqer/Financials/Exact/HoursByDate.php
@@ -65,5 +65,5 @@ class HoursByDate extends Model
         'WeekNumber',
     ];
 
-    protected $url = 'read/project/HoursByDate?checkDate={Edm.DateTime}';
+    protected $url = 'read/project/HoursByDate';
 }

--- a/src/Picqer/Financials/Exact/HoursById.php
+++ b/src/Picqer/Financials/Exact/HoursById.php
@@ -65,5 +65,5 @@ class HoursById extends Model
         'WeekNumber',
     ];
 
-    protected $url = 'read/project/HoursById?entryId={Edm.Guid}';
+    protected $url = 'read/project/HoursById';
 }

--- a/src/Picqer/Financials/Exact/ItemDetailsByID.php
+++ b/src/Picqer/Financials/Exact/ItemDetailsByID.php
@@ -29,5 +29,5 @@ class ItemDetailsByID extends Model
         'SalesPrice',
     ];
 
-    protected $url = 'read/logistics/ItemDetailsByID?itemId={Edm.Guid}';
+    protected $url = 'read/logistics/ItemDetailsByID';
 }

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -68,12 +68,8 @@ abstract class Model implements \JsonSerializable
      *
      * @return string
      */
-    public function url($id = null)
+    public function url()
     {
-        if (isset($id)) {
-            return str_replace('{Edm.Guid}', "guid'" . $id . "'", $this->url);
-        }
-
         return $this->url;
     }
 

--- a/src/Picqer/Financials/Exact/OpportunityDocument.php
+++ b/src/Picqer/Financials/Exact/OpportunityDocument.php
@@ -73,5 +73,5 @@ class OpportunityDocument extends Model
         'TypeDescription',
     ];
 
-    protected $url = 'read/crm/OpportunityDocuments?opportunityId={Edm.Guid}&searchText={Edm.String}';
+    protected $url = 'read/crm/OpportunityDocuments';
 }

--- a/src/Picqer/Financials/Exact/OpportunityDocumentsCount.php
+++ b/src/Picqer/Financials/Exact/OpportunityDocumentsCount.php
@@ -15,5 +15,5 @@ class OpportunityDocumentsCount extends Model
     protected $fillable = [
     ];
 
-    protected $url = 'read/crm/OpportunityDocumentsCount?opportunityId={Edm.Guid}&searchText={Edm.String}';
+    protected $url = 'read/crm/OpportunityDocumentsCount';
 }

--- a/src/Picqer/Financials/Exact/PayablesListByAccount.php
+++ b/src/Picqer/Financials/Exact/PayablesListByAccount.php
@@ -49,5 +49,5 @@ class PayablesListByAccount extends Model
         'YourRef',
     ];
 
-    protected $url = 'read/financial/PayablesListByAccount?accountId={Edm.Guid}';
+    protected $url = 'read/financial/PayablesListByAccount';
 }

--- a/src/Picqer/Financials/Exact/PayablesListByAccountAndAgeGroup.php
+++ b/src/Picqer/Financials/Exact/PayablesListByAccountAndAgeGroup.php
@@ -49,5 +49,5 @@ class PayablesListByAccountAndAgeGroup extends Model
         'YourRef',
     ];
 
-    protected $url = 'read/financial/PayablesListByAccountAndAgeGroup?accountId={Edm.Guid}&ageGroup={Edm.Int32}';
+    protected $url = 'read/financial/PayablesListByAccountAndAgeGroup';
 }

--- a/src/Picqer/Financials/Exact/PayablesListByAgeGroup.php
+++ b/src/Picqer/Financials/Exact/PayablesListByAgeGroup.php
@@ -49,5 +49,5 @@ class PayablesListByAgeGroup extends Model
         'YourRef',
     ];
 
-    protected $url = 'read/financial/PayablesListByAgeGroup?ageGroup={Edm.Int32}';
+    protected $url = 'read/financial/PayablesListByAgeGroup';
 }

--- a/src/Picqer/Financials/Exact/PreferredMailboxForOperation.php
+++ b/src/Picqer/Financials/Exact/PreferredMailboxForOperation.php
@@ -37,5 +37,5 @@ class PreferredMailboxForOperation extends Model
         'ValidTo',
     ];
 
-    protected $url = 'read/mailbox/PreferredMailboxForOperation?operation={Edm.Int32}';
+    protected $url = 'read/mailbox/PreferredMailboxForOperation';
 }

--- a/src/Picqer/Financials/Exact/ProjectWBSByProjectAndWBS.php
+++ b/src/Picqer/Financials/Exact/ProjectWBSByProjectAndWBS.php
@@ -72,5 +72,5 @@ class ProjectWBSByProjectAndWBS extends Model
         'Type',
     ];
 
-    protected $url = 'read/project/ProjectWBSByProjectAndWBS?projectId={Edm.Guid}&projectWBSId={Edm.Guid}&wbsType={Edm.Int16}';
+    protected $url = 'read/project/ProjectWBSByProjectAndWBS';
 }

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -31,7 +31,7 @@ trait Findable
             $filter = $this->primaryKey() . " eq $id";
         }
 
-        $records = $this->connection()->get($this->url($id), [
+        $records = $this->connection()->get($this->url(), [
             '$filter' => $filter,
             '$top'    => 1, // The result will always be 1 but on some entities Exact gives an error without it.
         ]);
@@ -44,7 +44,7 @@ trait Findable
     public function findWithSelect($id, $select = '')
     {
         //eg: $oAccounts->findWithSelect('5b7f4515-b7a0-4839-ac69-574968677d96', 'Code, Name');
-        $result = $this->connection()->get($this->url($id), [
+        $result = $this->connection()->get($this->url(), [
             '$filter' => $this->primaryKey() . " eq guid'$id'",
             '$select' => $select,
         ]);

--- a/src/Picqer/Financials/Exact/ReceivablesListByAccount.php
+++ b/src/Picqer/Financials/Exact/ReceivablesListByAccount.php
@@ -47,5 +47,5 @@ class ReceivablesListByAccount extends Model
         'YourRef',
     ];
 
-    protected $url = 'read/financial/ReceivablesListByAccount?accountId={Edm.Guid}';
+    protected $url = 'read/financial/ReceivablesListByAccount';
 }

--- a/src/Picqer/Financials/Exact/ReceivablesListByAccountAndAgeGroup.php
+++ b/src/Picqer/Financials/Exact/ReceivablesListByAccountAndAgeGroup.php
@@ -47,5 +47,5 @@ class ReceivablesListByAccountAndAgeGroup extends Model
         'YourRef',
     ];
 
-    protected $url = 'read/financial/ReceivablesListByAccountAndAgeGroup?accountId={Edm.Guid}&ageGroup={Edm.Int32}';
+    protected $url = 'read/financial/ReceivablesListByAccountAndAgeGroup';
 }

--- a/src/Picqer/Financials/Exact/ReceivablesListByAgeGroup.php
+++ b/src/Picqer/Financials/Exact/ReceivablesListByAgeGroup.php
@@ -47,5 +47,5 @@ class ReceivablesListByAgeGroup extends Model
         'YourRef',
     ];
 
-    protected $url = 'read/financial/ReceivablesListByAgeGroup?ageGroup={Edm.Int32}';
+    protected $url = 'read/financial/ReceivablesListByAgeGroup';
 }

--- a/src/Picqer/Financials/Exact/RecentCostsByNumberOfWeeks.php
+++ b/src/Picqer/Financials/Exact/RecentCostsByNumberOfWeeks.php
@@ -68,5 +68,5 @@ class RecentCostsByNumberOfWeeks extends Model
         'WeekNumber',
     ];
 
-    protected $url = 'read/project/RecentCostsByNumberOfWeeks?numberOfWeeks={Edm.Int32}';
+    protected $url = 'read/project/RecentCostsByNumberOfWeeks';
 }

--- a/src/Picqer/Financials/Exact/RevenueListByYear.php
+++ b/src/Picqer/Financials/Exact/RevenueListByYear.php
@@ -23,5 +23,5 @@ class RevenueListByYear extends Model
         'Amount',
     ];
 
-    protected $url = 'read/financial/RevenueListByYear?year={Edm.Int32}';
+    protected $url = 'read/financial/RevenueListByYear';
 }

--- a/src/Picqer/Financials/Exact/RevenueListByYearAndStatus.php
+++ b/src/Picqer/Financials/Exact/RevenueListByYearAndStatus.php
@@ -24,5 +24,5 @@ class RevenueListByYearAndStatus extends Model
         'Amount',
     ];
 
-    protected $url = 'read/financial/RevenueListByYearAndStatus?year={Edm.Int32}&afterEntry={Edm.Boolean}';
+    protected $url = 'read/financial/RevenueListByYearAndStatus';
 }

--- a/src/Picqer/Financials/Exact/TimeAndBillingAccountDetailsByID.php
+++ b/src/Picqer/Financials/Exact/TimeAndBillingAccountDetailsByID.php
@@ -19,5 +19,5 @@ class TimeAndBillingAccountDetailsByID extends Model
         'Name',
     ];
 
-    protected $url = 'read/project/TimeAndBillingAccountDetailsByID?accountId={Edm.Guid}';
+    protected $url = 'read/project/TimeAndBillingAccountDetailsByID';
 }

--- a/src/Picqer/Financials/Exact/TimeAndBillingEntryAccountsByDate.php
+++ b/src/Picqer/Financials/Exact/TimeAndBillingEntryAccountsByDate.php
@@ -21,5 +21,5 @@ class TimeAndBillingEntryAccountsByDate extends Model
         'AccountName',
     ];
 
-    protected $url = 'read/project/TimeAndBillingEntryAccountsByDate?checkDate={Edm.DateTime}';
+    protected $url = 'read/project/TimeAndBillingEntryAccountsByDate';
 }

--- a/src/Picqer/Financials/Exact/TimeAndBillingEntryAccountsByProjectAndDate.php
+++ b/src/Picqer/Financials/Exact/TimeAndBillingEntryAccountsByProjectAndDate.php
@@ -21,5 +21,5 @@ class TimeAndBillingEntryAccountsByProjectAndDate extends Model
         'AccountName',
     ];
 
-    protected $url = 'read/project/TimeAndBillingEntryAccountsByProjectAndDate?projectId={Edm.Guid}&checkDate={Edm.DateTime}';
+    protected $url = 'read/project/TimeAndBillingEntryAccountsByProjectAndDate';
 }

--- a/src/Picqer/Financials/Exact/TimeAndBillingEntryProjectsByAccountAndDate.php
+++ b/src/Picqer/Financials/Exact/TimeAndBillingEntryProjectsByAccountAndDate.php
@@ -23,5 +23,5 @@ class TimeAndBillingEntryProjectsByAccountAndDate extends Model
         'ProjectDescription',
     ];
 
-    protected $url = 'read/project/TimeAndBillingEntryProjectsByAccountAndDate?accountId={Edm.Guid}&checkDate={Edm.DateTime}';
+    protected $url = 'read/project/TimeAndBillingEntryProjectsByAccountAndDate';
 }

--- a/src/Picqer/Financials/Exact/TimeAndBillingEntryProjectsByDate.php
+++ b/src/Picqer/Financials/Exact/TimeAndBillingEntryProjectsByDate.php
@@ -23,5 +23,5 @@ class TimeAndBillingEntryProjectsByDate extends Model
         'ProjectDescription',
     ];
 
-    protected $url = 'read/project/TimeAndBillingEntryProjectsByDate?checkDate={Edm.DateTime}';
+    protected $url = 'read/project/TimeAndBillingEntryProjectsByDate';
 }

--- a/src/Picqer/Financials/Exact/TimeAndBillingItemDetailsByID.php
+++ b/src/Picqer/Financials/Exact/TimeAndBillingItemDetailsByID.php
@@ -29,5 +29,5 @@ class TimeAndBillingItemDetailsByID extends Model
         'SalesPrice',
     ];
 
-    protected $url = 'read/project/TimeAndBillingItemDetailsByID?itemId={Edm.Guid}';
+    protected $url = 'read/project/TimeAndBillingItemDetailsByID';
 }

--- a/src/Picqer/Financials/Exact/TimeAndBillingProjectDetailsByID.php
+++ b/src/Picqer/Financials/Exact/TimeAndBillingProjectDetailsByID.php
@@ -27,5 +27,5 @@ class TimeAndBillingProjectDetailsByID extends Model
         'Type',
     ];
 
-    protected $url = 'read/project/TimeAndBillingProjectDetailsByID?projectId={Edm.Guid}';
+    protected $url = 'read/project/TimeAndBillingProjectDetailsByID';
 }

--- a/src/Picqer/Financials/Exact/UserHasRights.php
+++ b/src/Picqer/Financials/Exact/UserHasRights.php
@@ -15,5 +15,5 @@ class UserHasRights extends Model
     protected $fillable = [
     ];
 
-    protected $url = 'users/UserHasRights?endpoint={Edm.String}&action={Edm.String}';
+    protected $url = 'users/UserHasRights';
 }

--- a/tests/QueryParamTest.php
+++ b/tests/QueryParamTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Picqer\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Picqer\Financials\Exact;
+use Picqer\Financials\Exact\Connection;
+
+class QueryParamTest extends TestCase
+{
+    /**
+     * @dataProvider ModelsWithSupportQueryParams
+     */
+    public function testGetRequestHasCorrectlyFormattedQueryParam(string $classString, array $supportedParams): void
+    {
+        $mockHandler = $this->createMockHandler();
+        $connection = $this->createMockConnection($mockHandler);
+        $sut = new $classString($connection);
+        $params = array_fill_keys($supportedParams, '00000000-0000-0000-0000-000000000000');
+
+        $sut->get($params);
+
+        $this->assertEquals(http_build_query($params), $mockHandler->getLastRequest()->getUri()->getQuery());
+    }
+
+    private function createMockConnection(callable $mockHandler): Connection
+    {
+        $handlerStack = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $handlerStack]);
+        $connection = new Connection();
+        $connection->setClient($client);
+        $connection->setDivision('1234567890');
+        $connection->setAccessToken('1234567890');
+        $connection->setTokenExpires(time() + 60);
+
+        return $connection;
+    }
+
+    private function createMockHandler(): MockHandler
+    {
+        return new MockHandler([
+            new Response(200, [], json_encode((object) [])),
+        ]);
+    }
+
+    public function ModelsWithSupportQueryParams(): array
+    {
+        return [
+            Exact\RecentCostsByNumberOfWeeks::class => [
+                Exact\RecentCostsByNumberOfWeeks::class,
+                ['numberOfWeeks'],
+            ],
+            Exact\PayablesListByAccountAndAgeGroup::class => [
+                Exact\PayablesListByAccountAndAgeGroup::class,
+                ['accountId', 'ageGroup'],
+            ],
+            Exact\CostEntryRecentAccountsByProject::class => [
+                Exact\CostEntryRecentAccountsByProject::class,
+                ['projectId'],
+            ],
+            Exact\PreferredMailboxForOperation::class => [
+                Exact\PreferredMailboxForOperation::class,
+                ['operation'],
+            ],
+            Exact\HourTypesByDate::class => [
+                Exact\HourTypesByDate::class,
+                ['checkDate'],
+            ],
+            Exact\CostTypesByProjectAndDate::class => [
+                Exact\CostTypesByProjectAndDate::class,
+                ['projectId', 'checkDate'],
+            ],
+            Exact\ReceivablesListByAccountAndAgeGroup::class => [
+                Exact\ReceivablesListByAccountAndAgeGroup::class,
+                ['accountId', 'ageGroup'],
+            ],
+            Exact\ReceivablesListByAgeGroup::class => [
+                Exact\ReceivablesListByAgeGroup::class,
+                ['ageGroup'],
+            ],
+            Exact\DefaultAddressForAccount::class => [
+                Exact\DefaultAddressForAccount::class,
+                ['accountId', 'addressType'],
+            ],
+            Exact\HoursById::class => [
+                Exact\HoursById::class,
+                ['entryId'],
+            ],
+            Exact\ProjectWBSByProjectAndWBS::class => [
+                Exact\ProjectWBSByProjectAndWBS::class,
+                ['projectId', 'projectWBSId', 'webType'],
+            ],
+            Exact\HourEntryRecentActivitiesByProject::class => [
+                Exact\HourEntryRecentActivitiesByProject::class,
+                ['projectId'],
+            ],
+            Exact\OpportunityDocumentsCount::class => [
+                Exact\OpportunityDocumentsCount::class,
+                ['opportunityId', 'searchText'],
+            ],
+            Exact\CostEntryRecentCostTypesByProject::class => [
+                Exact\CostEntryRecentCostTypesByProject::class,
+                ['projectId'],
+            ],
+            Exact\TimeAndBillingEntryAccountsByProjectAndDate::class => [
+                Exact\TimeAndBillingEntryAccountsByProjectAndDate::class,
+                ['projectId', 'checkDate'],
+            ],
+            Exact\HourTypesByProjectAndDate::class => [
+                Exact\HourTypesByProjectAndDate::class,
+                ['projectId', 'checkDate'],
+            ],
+            Exact\AccountDocumentCount::class => [
+                Exact\AccountDocumentCount::class,
+                ['accountId', 'searchText', 'useFullTextSearch'],
+            ],
+            Exact\AgingReceivablesListByAgeGroup::class => [
+                Exact\AgingReceivablesListByAgeGroup::class,
+                ['ageGroup'],
+            ],
+            Exact\CostsByDate::class => [
+                Exact\CostsByDate::class,
+                ['checkDate'],
+            ],
+            Exact\RevenueListByYearAndStatus::class => [
+                Exact\RevenueListByYearAndStatus::class,
+                ['year', 'afterEntry'],
+            ],
+            Exact\AgingPayablesListByAgeGroup::class => [
+                Exact\AgingPayablesListByAgeGroup::class,
+                ['ageGroup'],
+            ],
+            Exact\HoursByDate::class => [
+                Exact\HoursByDate::class,
+                ['checkDate'],
+            ],
+            Exact\AccountDocument::class => [
+                Exact\AccountDocument::class,
+                ['accountId', 'searchText', 'useFullTextSearch'],
+            ],
+            Exact\PayablesListByAgeGroup::class => [
+                Exact\PayablesListByAgeGroup::class,
+                ['ageGroup'],
+            ],
+            Exact\AccountDocumentFolder::class => [
+                Exact\AccountDocumentFolder::class,
+                ['accountId'],
+            ],
+            Exact\HourEntryActivitiesByProject::class => [
+                Exact\HourEntryActivitiesByProject::class,
+                ['projectId'],
+            ],
+            Exact\TimeAndBillingEntryAccountsByDate::class => [
+                Exact\TimeAndBillingEntryAccountsByDate::class,
+                ['checkDate'],
+            ],
+            Exact\CostsById::class => [
+                Exact\CostsById::class,
+                ['entryId'],
+            ],
+            Exact\ReceivablesListByAccount::class => [
+                Exact\ReceivablesListByAccount::class,
+                ['accountId'],
+            ],
+            Exact\RevenueListByYear::class => [
+                Exact\RevenueListByYear::class,
+                ['year'],
+            ],
+            Exact\AgingOverviewByAccount::class => [
+                Exact\AgingOverviewByAccount::class,
+                ['accountId'],
+            ],
+            Exact\HourEntryRecentAccountsByProject::class => [
+                Exact\HourEntryRecentAccountsByProject::class,
+                ['projectId'],
+            ],
+            Exact\PayablesListByAccount::class => [
+                Exact\PayablesListByAccount::class,
+                ['accountId'],
+            ],
+            Exact\TimeAndBillingAccountDetailsByID::class => [
+                Exact\TimeAndBillingAccountDetailsByID::class,
+                ['accountId'],
+            ],
+            Exact\CostTypesByDate::class => [
+                Exact\CostTypesByDate::class,
+                ['checkDate'],
+            ],
+            Exact\HourEntryRecentHourTypesByProject::class => [
+                Exact\HourEntryRecentHourTypesByProject::class,
+                ['projectId'],
+            ],
+            Exact\OpportunityDocument::class => [
+                Exact\OpportunityDocument::class,
+                ['opportunityId', 'searchText'],
+            ],
+            Exact\TimeAndBillingEntryProjectsByDate::class => [
+                Exact\TimeAndBillingEntryProjectsByDate::class,
+                ['checkDate'],
+            ],
+            Exact\TimeAndBillingItemDetailsByID::class => [
+                Exact\TimeAndBillingItemDetailsByID::class,
+                ['itemId'],
+            ],
+            Exact\CostEntryExpensesByProject::class => [
+                Exact\CostEntryExpensesByProject::class,
+                ['projectId'],
+            ],
+            Exact\UserHasRights::class => [
+                Exact\UserHasRights::class,
+                ['endpoint', 'action'],
+            ],
+            Exact\TimeAndBillingEntryProjectsByAccountAndDate::class => [
+                Exact\TimeAndBillingEntryProjectsByAccountAndDate::class,
+                ['accountId', 'checkDate'],
+            ],
+            Exact\TimeAndBillingProjectDetailsByID::class => [
+                Exact\TimeAndBillingProjectDetailsByID::class,
+                ['projectId'],
+            ],
+            Exact\ItemDetailsByID::class => [
+                Exact\ItemDetailsByID::class,
+                ['itemId'],
+            ],
+            Exact\CostEntryRecentExpensesByProject::class => [
+                Exact\CostEntryRecentExpensesByProject::class,
+                ['projectId'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This first commit has an added test that shows the incorrect query string for each model that has
a query string part to the `$url` property.

A second following commit (still to be added)  will implement the fix and make the test turn green.

This would fix the issue mentioned [here](https://github.com/picqer/exact-php-client/issues/424#issuecomment-1016256789) and confirmed [here](https://github.com/picqer/exact-php-client/issues/424#issuecomment-1016271875).