### PR TITLE
Update SalesInvoiceLine.php

### DIFF
--- a/src/Picqer/Financials/Exact/SalesInvoiceLine.php
+++ b/src/Picqer/Financials/Exact/SalesInvoiceLine.php
@@ -21,7 +21,7 @@ namespace Picqer\Financials\Exact;
  * @property int $Division Division code
  * @property string $Employee Link to Employee originating from time and cost transactions
  * @property string $EmployeeFullName Name of employee
- * @property string $EndTime EndTime is used to store the last date of a period. EndTime is used in combination with StartTime
+ * @property string $EndDate EndDate is used to store the last date of a period. EndDate is used in combination with StartDate
  * @property float $ExtraDutyAmountFC Extra duty amount in the currency of the transaction. Both extra duty amount and VAT amount need to be specified in order to differ this property from automatically calculated.
  * @property float $ExtraDutyPercentage Extra duty percentage
  * @property string $GLAccount The GL Account of the sales invoice line. This field is mandatory. This field is generated based on the revenue account of the item (or the related item group). G/L Account is also used to determine whether the costcenter / costunit is mandatory
@@ -44,7 +44,7 @@ namespace Picqer\Financials\Exact;
  * @property string $SalesOrderLine Identifies the sales order line this sales invoice line is based on
  * @property int $SalesOrderLineNumber Then line number of the sales order line on which this invoice line is based on
  * @property int $SalesOrderNumber The order number of the sales order on which this invoice line is based on
- * @property string $StartTime StartTime is used to store the first date of a period. StartTime is used in combination with EndTime
+ * @property string $StartDate StartDate is used to store the first date of a period. StartDate is used in combination with EndDate
  * @property string $Subscription When generating invoices from subscriptions, this field records the link between invoice lines and subscription lines
  * @property string $SubscriptionDescription Description of subscription line
  * @property string $UnitCode Code of Unit
@@ -76,7 +76,7 @@ class SalesInvoiceLine extends Model
         'Division',
         'Employee',
         'EmployeeFullName',
-        'EndTime',
+        'EndDate',
         'ExtraDutyAmountFC',
         'ExtraDutyPercentage',
         'GLAccount',
@@ -99,7 +99,7 @@ class SalesInvoiceLine extends Model
         'SalesOrderLine',
         'SalesOrderLineNumber',
         'SalesOrderNumber',
-        'StartTime',
+        'StartDate',
         'Subscription',
         'SubscriptionDescription',
         'UnitCode',


### PR DESCRIPTION
Although documentation mentions EndTime and StartTime it should be EndDate and StartDate. Exporting a salesinvoice from Exact shows those elements.

Fixes Issue #530 