### PR TITLE
Correct system users division from url

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -276,7 +276,7 @@ class Connection
     public function get($url, array $params = [], array $headers = [])
     {
         $this->waitIfMinutelyRateLimitHit();
-        $url = $this->formatUrl($url, $url !== 'current/Me', $url == $this->nextUrl);
+        $url = $this->formatUrl($url, $this->requiresDivisionInRequestUrl($url), $url === $this->nextUrl);
 
         try {
             $request = $this->createRequest('GET', $url, null, $params, $headers);
@@ -907,5 +907,13 @@ class Connection
     public function setWaitOnMinutelyRateLimitHit(bool $waitOnMinutelyRateLimitHit)
     {
         $this->waitOnMinutelyRateLimitHit = $waitOnMinutelyRateLimitHit;
+    }
+
+    private function requiresDivisionInRequestUrl(string $endpointUrl): bool
+    {
+        return ! in_array($endpointUrl, [
+            (new SystemUser($this))->url(),
+            (new Me($this))->url(),
+        ], true);
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Picqer\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Picqer\Financials\Exact\Connection;
+
+class ConnectionTest extends TestCase
+{
+    /**
+     * @dataProvider endpointsThatDontUseDivisionInUrl
+     */
+    public function testGetDoesntIncludeDivisionInUrlForSomeEndpoints(string $endpointUrl): void
+    {
+        $divisionNumber = random_int(0, PHP_INT_MAX);
+        $mockHandler = $this->createMockHandler();
+        $handlerStack = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $handlerStack]);
+        $connection = new Connection();
+        $connection->setClient($client);
+        $connection->setDivision($divisionNumber);
+        $connection->setAccessToken('1234567890');
+        $connection->setTokenExpires(time() + 60);
+
+        $connection->get($endpointUrl);
+
+        $this->assertStringNotContainsString((string) $divisionNumber, $mockHandler->getLastRequest()->getUri()->__toString());
+    }
+
+    public function testGetIncludesDivisionInUrlForRegularEndpoint(): void
+    {
+        $divisionNumber = random_int(0, PHP_INT_MAX);
+        $mockHandler = $this->createMockHandler();
+        $handlerStack = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $handlerStack]);
+        $connection = new Connection();
+        $connection->setClient($client);
+        $connection->setDivision($divisionNumber);
+        $connection->setAccessToken('1234567890');
+        $connection->setTokenExpires(time() + 60);
+
+        $connection->get('crm/Accounts');
+
+        $this->assertStringContainsString((string) $divisionNumber, $mockHandler->getLastRequest()->getUri()->__toString());
+    }
+
+    public function endpointsThatDontUseDivisionInUrl(): array
+    {
+        return [
+            'System users endpoint' => ['system/Users'],
+            'Me endpoint'           => ['current/Me'],
+        ];
+    }
+
+    private function createMockHandler(): MockHandler
+    {
+        return new MockHandler([
+            new Response(200, [], json_encode((object) [])),
+        ]);
+    }
+}


### PR DESCRIPTION
This PR fixes the issue raised in #534 and allows for an easy extension in case other urls might also be invoked without the division number.

Ideally I would have made this part of the Model as a property with a getter-method but given the context of the method has no knowledge other then the url being invoked I decided to go for this solution. No the ideal one but one that first in the context of this lib without creating BC breakage.