### PR TITLE
Provide return type attribute to handle php-8.1 exception

### DIFF
--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -271,6 +271,7 @@ abstract class Model implements \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->attributes;


### PR DESCRIPTION
Provide return type attribute to handle php-8.1 exception. 
I did not set  jsonSerialize():mixed as return type to remain compatible with php 7.2 ( composer.json )