### PR TITLE
Fix default value of params download method

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -341,7 +341,7 @@ class Connection
      *
      * @return mixed
      */
-    public function download($topic, $params = null)
+    public function download($topic, $params = [])
     {
         $url = $this->getBaseUrl() . '/docs/XMLDownload.aspx?Topic=' . $topic . '&_Division_=' . $this->getDivision();
 


### PR DESCRIPTION
Fix for exception (TypeError):
`Argument 4 passed to Picqer\Financials\Exact\Connection::createRequest() must be of the type array, null given, called in picqer/exact-php-client/src/Picqer/Financials/Exact/Connection.php on line 349`