### PR TITLE
Breaking: Drop PHP 7.2 7.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4.0",
         "guzzlehttp/guzzle": "~6.0|~7.0",
         "ext-json": "*"
     },


### PR DESCRIPTION
As discussed in #616.

Checked minimal Guzzle and PHPUnit versions and these are still correct, since the versions stated in composer.json support 7.4+. 