### PR TITLE
Feature:Add support for forced login while authorizing

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -71,6 +71,11 @@ class Connection
     private $redirectUrl;
 
     /**
+     * @var bool
+     */
+    private $forceLogin = false;
+
+    /**
      * @var string
      */
     private $state = null;
@@ -410,6 +415,7 @@ class Connection
             'redirect_uri'  => $this->redirectUrl,
             'response_type' => 'code',
             'state'         => $this->state,
+            'force_login'   => $this->forceLogin ? 1 : 0,
         ]);
     }
 
@@ -466,6 +472,14 @@ class Connection
     public function setRedirectUrl($redirectUrl)
     {
         $this->redirectUrl = $redirectUrl;
+    }
+
+    /**
+     * @param bool $forceLogin
+     */
+    public function setForceLogin($forceLogin)
+    {
+        $this->forceLogin = $forceLogin;
     }
 
     /**


### PR DESCRIPTION
This adds support for ignoring the current browser session for Exact Online while authorising your client. 
Docs: https://support.exactonline.com/community/s/knowledge-base#All-All-DNO-Content-oauth-eol-oauth-devstep2

Default behaviour is not changed, this does use an active Exact Online session for authorisation.