### PR TITLE
refactor: Add more native type hints

### DIFF
--- a/src/Picqer/Financials/Exact/DocumentAttachment.php
+++ b/src/Picqer/Financials/Exact/DocumentAttachment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Picqer\Financials\Exact;
 
 /**
@@ -31,10 +33,7 @@ class DocumentAttachment extends Model
 
     protected $url = 'documents/DocumentAttachments';
 
-    /**
-     * @return string
-     */
-    public function getDownloadUrl()
+    public function getDownloadUrl(): string
     {
         return $this->Url . '&Download=1';
     }

--- a/src/Picqer/Financials/Exact/Item.php
+++ b/src/Picqer/Financials/Exact/Item.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Picqer\Financials\Exact;
 
 /**
@@ -229,10 +231,7 @@ class Item extends Model
 
     protected $url = 'logistics/Items';
 
-    /**
-     * @return string
-     */
-    public function getDownloadUrl()
+    public function getDownloadUrl(): string
     {
         return $this->PictureUrl;
     }

--- a/src/Picqer/Financials/Exact/Model.php
+++ b/src/Picqer/Financials/Exact/Model.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Picqer\Financials\Exact;
 
 /**
@@ -7,20 +9,11 @@ namespace Picqer\Financials\Exact;
  */
 abstract class Model implements \JsonSerializable
 {
-    /**
-     * @var Connection
-     */
-    protected $connection;
+    protected Connection $connection;
 
-    /**
-     * @var array The model's attributes
-     */
-    protected $attributes = [];
+    protected array $attributes = [];
 
-    /**
-     * @deferred array The model's collection values
-     */
-    protected $deferred = [];
+    protected array $deferred = [];
 
     /**
      * @var array The model's fillable attributes
@@ -45,10 +38,8 @@ abstract class Model implements \JsonSerializable
 
     /**
      * Get the connection instance.
-     *
-     * @return Connection
      */
-    public function connection()
+    public function connection(): Connection
     {
         return $this->connection;
     }
@@ -56,29 +47,25 @@ abstract class Model implements \JsonSerializable
     /**
      * Get the model's attributes.
      *
-     * @return array
+     * @return array<string, mixed>
      */
-    public function attributes()
+    public function attributes(): array
     {
         return $this->attributes;
     }
 
     /**
      * Get the model's url.
-     *
-     * @return string
      */
-    public function url()
+    public function url(): string
     {
         return $this->url;
     }
 
     /**
      * Get the model's primary key.
-     *
-     * @return string
      */
-    public function primaryKey()
+    public function primaryKey(): string
     {
         return $this->primaryKey;
     }
@@ -96,7 +83,7 @@ abstract class Model implements \JsonSerializable
     /**
      * Fill the entity from an array.
      *
-     * @param array $attributes
+     * @param array<string, mixed> $attributes
      */
     protected function fill(array $attributes)
     {
@@ -110,9 +97,9 @@ abstract class Model implements \JsonSerializable
     /**
      * Get the fillable attributes of an array.
      *
-     * @param array $attributes
+     * @param array<string, mixed> $attributes
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function fillableFromArray(array $attributes)
     {
@@ -123,31 +110,30 @@ abstract class Model implements \JsonSerializable
         return $attributes;
     }
 
-    protected function isFillable($key)
+    protected function isFillable($key): bool
     {
         return in_array($key, $this->fillable);
     }
 
-    public function getFillable()
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFillable(): array
     {
         return $this->fillable;
     }
 
-    protected function setAttribute($key, $value)
+    protected function setAttribute($key, $value): void
     {
         $this->attributes[$key] = $value;
     }
 
     /**
      * Resolve deferred values.
-     *
-     * @param string $key
-     *
-     * @return bool Returns true when collection is found
      */
-    protected function lazyLoad($key)
+    protected function lazyLoad(string $key): bool
     {
-        // Check previously resolved or manualy set.
+        // Check previously resolved or manually set.
         if (isset($this->deferred[$key])) {
             return true;
         }
@@ -170,7 +156,7 @@ abstract class Model implements \JsonSerializable
         return false;
     }
 
-    public function __get($key)
+    public function __get(string $key)
     {
         if ($this->lazyLoad($key)) {
             return $this->deferred[$key];
@@ -181,7 +167,7 @@ abstract class Model implements \JsonSerializable
         }
     }
 
-    public function __set($key, $value)
+    public function __set(string $key, $value)
     {
         if ($this->isFillable($key)) {
             if (is_array($value)) {
@@ -194,12 +180,12 @@ abstract class Model implements \JsonSerializable
         }
     }
 
-    public function __isset($name)
+    public function __isset(string $name)
     {
         return $this->__get($name) !== null;
     }
 
-    public function __call($name, $arguments)
+    public function __call(string $name, $arguments)
     {
         return $this->__get($name);
     }
@@ -220,10 +206,8 @@ abstract class Model implements \JsonSerializable
 
     /**
      * Checks if primaryKey holds a value.
-     *
-     * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         if (! array_key_exists($this->primaryKey, $this->attributes)) {
             return false;
@@ -234,12 +218,8 @@ abstract class Model implements \JsonSerializable
 
     /**
      * Return the JSON representation of the data.
-     *
-     * @param int $options http://php.net/manual/en/json.constants.php
-     *
-     * @return string
      */
-    public function json($options = 0, $withDeferred = false)
+    public function json(int $options = 0, bool $withDeferred = false): string
     {
         $attributes = $this->attributes;
         if ($withDeferred) {
@@ -269,10 +249,10 @@ abstract class Model implements \JsonSerializable
     /**
      * Return serializable data.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->attributes;
     }
@@ -280,12 +260,8 @@ abstract class Model implements \JsonSerializable
     /**
      * Check whether the current user has rights for an action on this endpoint
      * https://start.exactonline.nl/docs/HlpRestAPIResources.aspx?SourceAction=10.
-     *
-     * @param string $action
-     *
-     * @return bool|null
      */
-    public function userHasRights($action = 'GET')
+    public function userHasRights(string $action = 'GET'): ?bool
     {
         $action = preg_match('/^GET|POST|PUT|DELETE$/i', $action) ? strtoupper($action) : 'GET';
         $result = $this->connection()->get('users/UserHasRights', [
@@ -293,6 +269,6 @@ abstract class Model implements \JsonSerializable
             'action'   => "'{$action}'",
         ]);
 
-        return isset($result['UserHasRights']) ? $result['UserHasRights'] : null;
+        return $result['UserHasRights'] ?? null;
     }
 }

--- a/src/Picqer/Financials/Exact/Persistance/Downloadable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Downloadable.php
@@ -4,23 +4,15 @@ namespace Picqer\Financials\Exact\Persistance;
 
 use GuzzleHttp\Client;
 use Picqer\Financials\Exact\Connection;
+use Psr\Http\Message\StreamInterface;
 
 trait Downloadable
 {
-    /**
-     * @return Connection
-     */
-    abstract public function connection();
+    abstract public function connection(): Connection;
 
-    /**
-     * @return string
-     */
-    abstract public function getDownloadUrl();
+    abstract public function getDownloadUrl(): string;
 
-    /**
-     * @return mixed Binary representation of file
-     */
-    public function download()
+    public function download(): StreamInterface
     {
         $client = new Client();
 

--- a/src/Picqer/Financials/Exact/Persistance/Storable.php
+++ b/src/Picqer/Financials/Exact/Persistance/Storable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Picqer\Financials\Exact\Persistance;
 
 use Picqer\Financials\Exact\ApiException;
@@ -7,33 +9,18 @@ use Picqer\Financials\Exact\Connection;
 
 trait Storable
 {
-    /**
-     * @return bool
-     */
-    abstract public function exists();
+    abstract public function exists(): bool;
 
     /**
-     * @param array $attributes
+     * @param array<string, mixed> $attributes
      */
     abstract protected function fill(array $attributes);
 
-    /**
-     * @param int  $options
-     * @param bool $withDeferred
-     *
-     * @return string
-     */
-    abstract public function json($options = 0, $withDeferred = false);
+    abstract public function json(int $options = 0, bool $withDeferred = false): string;
 
-    /**
-     * @return Connection
-     */
-    abstract public function connection();
+    abstract public function connection(): Connection;
 
-    /**
-     * @return string
-     */
-    abstract public function url();
+    abstract public function url(): string;
 
     /**
      * @return mixed
@@ -45,7 +32,7 @@ trait Storable
      *
      * @return $this
      */
-    public function save()
+    public function save(): self
     {
         if ($this->exists()) {
             $this->fill($this->update());

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Picqer\Financials\Exact\Query;
 
 use Generator;
@@ -17,12 +19,9 @@ trait Findable
     /**
      * @return string
      */
-    abstract public function url();
+    abstract public function url(): string;
 
-    /**
-     * @return string
-     */
-    abstract public function primaryKey();
+    abstract public function primaryKey(): string;
 
     public function find($id)
     {

--- a/src/Picqer/Financials/Exact/Query/Resultset.php
+++ b/src/Picqer/Financials/Exact/Query/Resultset.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Picqer\Financials\Exact\Query;
 
 use Generator;
@@ -10,35 +12,18 @@ use Picqer\Financials\Exact\Connection;
  */
 class Resultset
 {
-    /**
-     * @var Connection
-     */
-    protected $connection;
+    protected Connection $connection;
+
+    protected ?string $url;
+
+    protected string $class;
+
+    protected array $params;
 
     /**
-     * @var string
+     * @param array<string, mixed> $params
      */
-    protected $url;
-
-    /**
-     * @var string
-     */
-    protected $class;
-
-    /**
-     * @var array
-     */
-    protected $params;
-
-    /**
-     * Resultset constructor.
-     *
-     * @param Connection $connection
-     * @param string     $url
-     * @param string     $class
-     * @param array      $params
-     */
-    public function __construct(Connection $connection, $url, $class, array $params)
+    public function __construct(Connection $connection, ?string $url, string $class, array $params)
     {
         $this->connection = $connection;
         $this->url = $url;
@@ -60,10 +45,7 @@ class Resultset
         return $this->collectionFromResultAsGenerator($result);
     }
 
-    /**
-     * @return bool
-     */
-    public function hasMore()
+    public function hasMore(): bool
     {
         return $this->url !== null;
     }

--- a/src/Picqer/Financials/Exact/Webhook/Authenticatable.php
+++ b/src/Picqer/Financials/Exact/Webhook/Authenticatable.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Picqer\Financials\Exact\Webhook;
 
 trait Authenticatable
 {
-    public function authenticate($requestContent, $webhookSecret)
+    public function authenticate(string $requestContent, string$webhookSecret): bool
     {
         $matches = [];
         $matched = preg_match('/^{"Content":(.*),"HashCode":"(.*)"}$/', $requestContent, $matches);

--- a/src/Picqer/Financials/Exact/Webhook/Authenticatable.php
+++ b/src/Picqer/Financials/Exact/Webhook/Authenticatable.php
@@ -6,7 +6,7 @@ namespace Picqer\Financials\Exact\Webhook;
 
 trait Authenticatable
 {
-    public function authenticate(string $requestContent, string$webhookSecret): bool
+    public function authenticate(string $requestContent, string $webhookSecret): bool
     {
         $matches = [];
         $matched = preg_match('/^{"Content":(.*),"HashCode":"(.*)"}$/', $requestContent, $matches);


### PR DESCRIPTION
This PR follows up on #625 and adds more type hints into the library. I did a couple of test runs in order to validate all works as it should.

My current focus is to first add type hints to all the non generated bits and bobs of code and at some point update the generating code to update all the models with the types, such as adding the hints for:
- `protected array $fillable = [ ... ]`
- `protected string $url`
- `protected string $primaryKey`