### PR TITLE
Optional parameters when uploading XML

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -265,17 +265,18 @@ class Connection
     /**
      * @param string $topic
      * @param mixed  $body
+     * @param array  $params
      *
      * @throws ApiException
      *
      * @return mixed
      */
-    public function upload($topic, $body)
+    public function upload($topic, $body, $params = [])
     {
         $url = $this->getBaseUrl() . '/docs/XMLUpload.aspx?Topic=' . $topic . '&_Division_=' . $this->getDivision();
 
         try {
-            $request = $this->createRequest('POST', $url, $body);
+            $request = $this->createRequest('POST', $url, $body, $params);
             $response = $this->client()->send($request);
 
             return $this->parseResponseXml($response);


### PR DESCRIPTION
Pass optional parameters when uploading an xml to Exact.

For example add Params_Journal for the GLTransactions topic. 
See "Upload data" on https://support.exactonline.com/community/s/knowledge-base#All-All-DNO-Content-xmlsamplecode
