### PR TITLE
Log the response body if the json_encode() fails.

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -451,9 +451,10 @@ class Connection
             }
 
             Psr7\Message::rewindBody($response);
-            $json = json_decode($response->getBody()->getContents(), true);
+            $responseBody = $response->getBody()->getContents();
+            $json = json_decode($responseBody, true);
             if (false === is_array($json)) {
-                throw new ApiException('Json decode failed. Got response: ' . $response->getBody()->getContents());
+                throw new ApiException('Json decode failed. Got response: ' . $responseBody);
             }
             if (array_key_exists('d', $json)) {
                 if (array_key_exists('__next', $json['d'])) {
@@ -603,7 +604,8 @@ class Connection
             $response = $this->client()->post($this->getTokenUrl(), $body);
 
             Psr7\Message::rewindBody($response);
-            $body = json_decode($response->getBody()->getContents(), true);
+            $responseBody = $response->getBody()->getContents();
+            $body = json_decode($responseBody, true);
 
             if (json_last_error() === JSON_ERROR_NONE) {
                 $this->accessToken = $body['access_token'];
@@ -614,7 +616,7 @@ class Connection
                     call_user_func($this->tokenUpdateCallback, $this);
                 }
             } else {
-                throw new ApiException('Could not acquire tokens, json decode failed. Got response: ' . $response->getBody()->getContents());
+                throw new ApiException('Could not acquire tokens, json decode failed. Got response: ' . $responseBody);
             }
         } catch (BadResponseException $ex) {
             $this->parseExceptionForErrorMessages($ex);


### PR DESCRIPTION
On 2 places (that I could find), if the `json_decode()` fails, the respone-body was logged in the exception that was thrown. Although, that was the intention.

The PSR response `->getBody()->getContents()` is a stream, which needs to be rewinded before accessing (for a second time), just like is done when performing the `json_decode()`. This was not done when the exception was thrown, but the contents were requested again.
This resulted in an exception without the actual response-body (it was empty).

I personally didn't feel like rewinding the stream _again_, so I decided to put the response-body in a separate variable and use that variable in the logging.
I also added some tests for it.

Let me know what you think, I'm open to feedback :)