### PR TITLE
Upgrade phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.3"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="./vendor/autoload.php"
-         colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        bootstrap="./vendor/autoload.php"
+        colors="true"
+        xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd">
+
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+
   <testsuites>
-    <testsuite name="Application Test Suite">
+    <testsuite name="Exact PHP Client Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -89,12 +89,11 @@ class ConnectionTest extends TestCase
         $connection->get('crm/Accounts');
     }
 
-    public function endpointsThatDontUseDivisionInUrl(): array
+    public function endpointsThatDontUseDivisionInUrl(): \Generator
     {
-        return [
-            'System users endpoint' => ['system/Users'],
-            'Me endpoint'           => ['current/Me'],
-        ];
+
+        yield 'System users endpoint' => ['system/Users'];
+        yield 'Me endpoint'           => ['current/Me'];
     }
 
     private function createMockHandler(): MockHandler

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -91,7 +91,6 @@ class ConnectionTest extends TestCase
 
     public function endpointsThatDontUseDivisionInUrl(): \Generator
     {
-
         yield 'System users endpoint' => ['system/Users'];
         yield 'Me endpoint'           => ['current/Me'];
     }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -54,7 +54,7 @@ class ModelTest extends TestCase
         $response = (new Item($connection))->getAsGenerator();
 
         $this->assertInstanceOf(Generator::class, $response);
-        $this->assertCount(2, $response);
+        $this->assertEquals(2, iterator_count($response));
     }
 
     public function testCanFilterModels()
@@ -77,7 +77,7 @@ class ModelTest extends TestCase
         $response = (new Item($connection))->filterAsGenerator('IsWebshopItem eq 0');
 
         $this->assertInstanceOf(Generator::class, $response);
-        $this->assertCount(2, $response);
+        $this->assertEquals(2, iterator_count($response));
     }
 
     public function testCanGetCollectionFromResult()
@@ -104,7 +104,7 @@ class ModelTest extends TestCase
         $collection = $item->collectionFromResultAsGenerator($result);
 
         $this->assertInstanceOf(Generator::class, $collection);
-        $this->assertCount(2, $collection);
+        $this->assertEquals(2, iterator_count($collection));
     }
 
     public function testCanGetResultSet()

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -2,7 +2,6 @@
 
 namespace Picqer\Tests;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 use Picqer\Financials\Exact\Item;
 use Picqer\Financials\Exact\Query\Resultset;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -12,7 +12,7 @@ class ModelTest extends TestCase
 {
     use MocksExactConnection;
 
-    public function testCanFindModel()
+    public function testCanFindModel(): void
     {
         $handler = $this->createMockHandlerUsingFixture('item.json');
         $connection = $this->createMockConnection($handler);
@@ -23,7 +23,7 @@ class ModelTest extends TestCase
         $this->assertEquals('00000000-0000-0000-0000-000000000000', $response->primaryKeyContent());
     }
 
-    public function testCanGetFirstModel()
+    public function testCanGetFirstModel(): void
     {
         $handler = $this->createMockHandlerUsingFixture('item.json');
         $connection = $this->createMockConnection($handler);
@@ -34,7 +34,7 @@ class ModelTest extends TestCase
         $this->assertEquals('00000000-0000-0000-0000-000000000000', $response->primaryKeyContent());
     }
 
-    public function testCanGetModels()
+    public function testCanGetModels(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);
@@ -46,18 +46,17 @@ class ModelTest extends TestCase
         $this->assertCount(2, $response);
     }
 
-    public function testCanGetModelsAsGenerator()
+    public function testCanGetModelsAsGenerator(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);
 
         $response = (new Item($connection))->getAsGenerator();
 
-        $this->assertInstanceOf(Generator::class, $response);
         $this->assertEquals(2, iterator_count($response));
     }
 
-    public function testCanFilterModels()
+    public function testCanFilterModels(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);
@@ -69,18 +68,17 @@ class ModelTest extends TestCase
         $this->assertCount(2, $response);
     }
 
-    public function testCanFilterModelsAsGenerator()
+    public function testCanFilterModelsAsGenerator(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);
 
         $response = (new Item($connection))->filterAsGenerator('IsWebshopItem eq 0');
 
-        $this->assertInstanceOf(Generator::class, $response);
         $this->assertEquals(2, iterator_count($response));
     }
 
-    public function testCanGetCollectionFromResult()
+    public function testCanGetCollectionFromResult(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);
@@ -94,7 +92,7 @@ class ModelTest extends TestCase
         $this->assertCount(2, $collection);
     }
 
-    public function testCanGetCollectionFromResultAsGenerator()
+    public function testCanGetCollectionFromResultAsGenerator(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);
@@ -103,18 +101,16 @@ class ModelTest extends TestCase
         $result = $connection->get($item->url(), []);
         $collection = $item->collectionFromResultAsGenerator($result);
 
-        $this->assertInstanceOf(Generator::class, $collection);
         $this->assertEquals(2, iterator_count($collection));
     }
 
-    public function testCanGetResultSet()
+    public function testCanGetResultSet(): void
     {
         $handler = $this->createMockHandler();
         $connection = $this->createMockConnection($handler);
-        $item = new Item($connection);
 
-        $resultset = (new Item($connection))->getResultSet();
+        $resultSet = (new Item($connection))->getResultSet();
 
-        $this->assertInstanceOf(Resultset::class, $resultset);
+        $this->assertInstanceOf(Resultset::class, $resultSet);
     }
 }

--- a/tests/QueryParamTest.php
+++ b/tests/QueryParamTest.php
@@ -28,189 +28,187 @@ class QueryParamTest extends TestCase
         $this->assertEquals(http_build_query($params), $mockHandler->getLastRequest()->getUri()->getQuery());
     }
 
-    public function ModelsWithSupportQueryParams(): array
+    public function ModelsWithSupportQueryParams(): \Generator
     {
-        return [
-            Exact\RecentCostsByNumberOfWeeks::class => [
-                Exact\RecentCostsByNumberOfWeeks::class,
-                ['numberOfWeeks'],
-            ],
-            Exact\PayablesListByAccountAndAgeGroup::class => [
-                Exact\PayablesListByAccountAndAgeGroup::class,
-                ['accountId', 'ageGroup'],
-            ],
-            Exact\CostEntryRecentAccountsByProject::class => [
-                Exact\CostEntryRecentAccountsByProject::class,
-                ['projectId'],
-            ],
-            Exact\PreferredMailboxForOperation::class => [
-                Exact\PreferredMailboxForOperation::class,
-                ['operation'],
-            ],
-            Exact\HourTypesByDate::class => [
-                Exact\HourTypesByDate::class,
-                ['checkDate'],
-            ],
-            Exact\CostTypesByProjectAndDate::class => [
-                Exact\CostTypesByProjectAndDate::class,
-                ['projectId', 'checkDate'],
-            ],
-            Exact\ReceivablesListByAccountAndAgeGroup::class => [
-                Exact\ReceivablesListByAccountAndAgeGroup::class,
-                ['accountId', 'ageGroup'],
-            ],
-            Exact\ReceivablesListByAgeGroup::class => [
-                Exact\ReceivablesListByAgeGroup::class,
-                ['ageGroup'],
-            ],
-            Exact\DefaultAddressForAccount::class => [
-                Exact\DefaultAddressForAccount::class,
-                ['accountId', 'addressType'],
-            ],
-            Exact\HoursById::class => [
-                Exact\HoursById::class,
-                ['entryId'],
-            ],
-            Exact\ProjectWBSByProjectAndWBS::class => [
-                Exact\ProjectWBSByProjectAndWBS::class,
-                ['projectId', 'projectWBSId', 'webType'],
-            ],
-            Exact\HourEntryRecentActivitiesByProject::class => [
-                Exact\HourEntryRecentActivitiesByProject::class,
-                ['projectId'],
-            ],
-            Exact\OpportunityDocumentsCount::class => [
-                Exact\OpportunityDocumentsCount::class,
-                ['opportunityId', 'searchText'],
-            ],
-            Exact\CostEntryRecentCostTypesByProject::class => [
-                Exact\CostEntryRecentCostTypesByProject::class,
-                ['projectId'],
-            ],
-            Exact\TimeAndBillingEntryAccountsByProjectAndDate::class => [
-                Exact\TimeAndBillingEntryAccountsByProjectAndDate::class,
-                ['projectId', 'checkDate'],
-            ],
-            Exact\HourTypesByProjectAndDate::class => [
-                Exact\HourTypesByProjectAndDate::class,
-                ['projectId', 'checkDate'],
-            ],
-            Exact\AccountDocumentCount::class => [
-                Exact\AccountDocumentCount::class,
-                ['accountId', 'searchText', 'useFullTextSearch'],
-            ],
-            Exact\AgingReceivablesListByAgeGroup::class => [
-                Exact\AgingReceivablesListByAgeGroup::class,
-                ['ageGroup'],
-            ],
-            Exact\CostsByDate::class => [
-                Exact\CostsByDate::class,
-                ['checkDate'],
-            ],
-            Exact\RevenueListByYearAndStatus::class => [
-                Exact\RevenueListByYearAndStatus::class,
-                ['year', 'afterEntry'],
-            ],
-            Exact\AgingPayablesListByAgeGroup::class => [
-                Exact\AgingPayablesListByAgeGroup::class,
-                ['ageGroup'],
-            ],
-            Exact\HoursByDate::class => [
-                Exact\HoursByDate::class,
-                ['checkDate'],
-            ],
-            Exact\AccountDocument::class => [
-                Exact\AccountDocument::class,
-                ['accountId', 'searchText', 'useFullTextSearch'],
-            ],
-            Exact\PayablesListByAgeGroup::class => [
-                Exact\PayablesListByAgeGroup::class,
-                ['ageGroup'],
-            ],
-            Exact\AccountDocumentFolder::class => [
-                Exact\AccountDocumentFolder::class,
-                ['accountId'],
-            ],
-            Exact\HourEntryActivitiesByProject::class => [
-                Exact\HourEntryActivitiesByProject::class,
-                ['projectId'],
-            ],
-            Exact\TimeAndBillingEntryAccountsByDate::class => [
-                Exact\TimeAndBillingEntryAccountsByDate::class,
-                ['checkDate'],
-            ],
-            Exact\CostsById::class => [
-                Exact\CostsById::class,
-                ['entryId'],
-            ],
-            Exact\ReceivablesListByAccount::class => [
-                Exact\ReceivablesListByAccount::class,
-                ['accountId'],
-            ],
-            Exact\RevenueListByYear::class => [
-                Exact\RevenueListByYear::class,
-                ['year'],
-            ],
-            Exact\AgingOverviewByAccount::class => [
-                Exact\AgingOverviewByAccount::class,
-                ['accountId'],
-            ],
-            Exact\HourEntryRecentAccountsByProject::class => [
-                Exact\HourEntryRecentAccountsByProject::class,
-                ['projectId'],
-            ],
-            Exact\PayablesListByAccount::class => [
-                Exact\PayablesListByAccount::class,
-                ['accountId'],
-            ],
-            Exact\TimeAndBillingAccountDetailsByID::class => [
-                Exact\TimeAndBillingAccountDetailsByID::class,
-                ['accountId'],
-            ],
-            Exact\CostTypesByDate::class => [
-                Exact\CostTypesByDate::class,
-                ['checkDate'],
-            ],
-            Exact\HourEntryRecentHourTypesByProject::class => [
-                Exact\HourEntryRecentHourTypesByProject::class,
-                ['projectId'],
-            ],
-            Exact\OpportunityDocument::class => [
-                Exact\OpportunityDocument::class,
-                ['opportunityId', 'searchText'],
-            ],
-            Exact\TimeAndBillingEntryProjectsByDate::class => [
-                Exact\TimeAndBillingEntryProjectsByDate::class,
-                ['checkDate'],
-            ],
-            Exact\TimeAndBillingItemDetailsByID::class => [
-                Exact\TimeAndBillingItemDetailsByID::class,
-                ['itemId'],
-            ],
-            Exact\CostEntryExpensesByProject::class => [
-                Exact\CostEntryExpensesByProject::class,
-                ['projectId'],
-            ],
-            Exact\UserHasRights::class => [
-                Exact\UserHasRights::class,
-                ['endpoint', 'action'],
-            ],
-            Exact\TimeAndBillingEntryProjectsByAccountAndDate::class => [
-                Exact\TimeAndBillingEntryProjectsByAccountAndDate::class,
-                ['accountId', 'checkDate'],
-            ],
-            Exact\TimeAndBillingProjectDetailsByID::class => [
-                Exact\TimeAndBillingProjectDetailsByID::class,
-                ['projectId'],
-            ],
-            Exact\ItemDetailsByID::class => [
-                Exact\ItemDetailsByID::class,
-                ['itemId'],
-            ],
-            Exact\CostEntryRecentExpensesByProject::class => [
-                Exact\CostEntryRecentExpensesByProject::class,
-                ['projectId'],
-            ],
+        yield Exact\RecentCostsByNumberOfWeeks::class => [
+            Exact\RecentCostsByNumberOfWeeks::class,
+            ['numberOfWeeks'],
+        ];
+        yield Exact\PayablesListByAccountAndAgeGroup::class => [
+            Exact\PayablesListByAccountAndAgeGroup::class,
+            ['accountId', 'ageGroup'],
+        ];
+        yield Exact\CostEntryRecentAccountsByProject::class => [
+            Exact\CostEntryRecentAccountsByProject::class,
+            ['projectId'],
+        ];
+        yield Exact\PreferredMailboxForOperation::class => [
+            Exact\PreferredMailboxForOperation::class,
+            ['operation'],
+        ];
+        yield Exact\HourTypesByDate::class => [
+            Exact\HourTypesByDate::class,
+            ['checkDate'],
+        ];
+        yield Exact\CostTypesByProjectAndDate::class => [
+            Exact\CostTypesByProjectAndDate::class,
+            ['projectId', 'checkDate'],
+        ];
+        yield Exact\ReceivablesListByAccountAndAgeGroup::class => [
+            Exact\ReceivablesListByAccountAndAgeGroup::class,
+            ['accountId', 'ageGroup'],
+        ];
+        yield Exact\ReceivablesListByAgeGroup::class => [
+            Exact\ReceivablesListByAgeGroup::class,
+            ['ageGroup'],
+        ];
+        yield Exact\DefaultAddressForAccount::class => [
+            Exact\DefaultAddressForAccount::class,
+            ['accountId', 'addressType'],
+        ];
+        yield Exact\HoursById::class => [
+            Exact\HoursById::class,
+            ['entryId'],
+        ];
+        yield Exact\ProjectWBSByProjectAndWBS::class => [
+            Exact\ProjectWBSByProjectAndWBS::class,
+            ['projectId', 'projectWBSId', 'webType'],
+        ];
+        yield Exact\HourEntryRecentActivitiesByProject::class => [
+            Exact\HourEntryRecentActivitiesByProject::class,
+            ['projectId'],
+        ];
+        yield Exact\OpportunityDocumentsCount::class => [
+            Exact\OpportunityDocumentsCount::class,
+            ['opportunityId', 'searchText'],
+        ];
+        yield Exact\CostEntryRecentCostTypesByProject::class => [
+            Exact\CostEntryRecentCostTypesByProject::class,
+            ['projectId'],
+        ];
+        yield Exact\TimeAndBillingEntryAccountsByProjectAndDate::class => [
+            Exact\TimeAndBillingEntryAccountsByProjectAndDate::class,
+            ['projectId', 'checkDate'],
+        ];
+        yield Exact\HourTypesByProjectAndDate::class => [
+            Exact\HourTypesByProjectAndDate::class,
+            ['projectId', 'checkDate'],
+        ];
+        yield Exact\AccountDocumentCount::class => [
+            Exact\AccountDocumentCount::class,
+            ['accountId', 'searchText', 'useFullTextSearch'],
+        ];
+        yield Exact\AgingReceivablesListByAgeGroup::class => [
+            Exact\AgingReceivablesListByAgeGroup::class,
+            ['ageGroup'],
+        ];
+        yield Exact\CostsByDate::class => [
+            Exact\CostsByDate::class,
+            ['checkDate'],
+        ];
+        yield Exact\RevenueListByYearAndStatus::class => [
+            Exact\RevenueListByYearAndStatus::class,
+            ['year', 'afterEntry'],
+        ];
+        yield Exact\AgingPayablesListByAgeGroup::class => [
+            Exact\AgingPayablesListByAgeGroup::class,
+            ['ageGroup'],
+        ];
+        yield Exact\HoursByDate::class => [
+            Exact\HoursByDate::class,
+            ['checkDate'],
+        ];
+        yield Exact\AccountDocument::class => [
+            Exact\AccountDocument::class,
+            ['accountId', 'searchText', 'useFullTextSearch'],
+        ];
+        yield Exact\PayablesListByAgeGroup::class => [
+            Exact\PayablesListByAgeGroup::class,
+            ['ageGroup'],
+        ];
+        yield Exact\AccountDocumentFolder::class => [
+            Exact\AccountDocumentFolder::class,
+            ['accountId'],
+        ];
+        yield Exact\HourEntryActivitiesByProject::class => [
+            Exact\HourEntryActivitiesByProject::class,
+            ['projectId'],
+        ];
+        yield Exact\TimeAndBillingEntryAccountsByDate::class => [
+            Exact\TimeAndBillingEntryAccountsByDate::class,
+            ['checkDate'],
+        ];
+        yield Exact\CostsById::class => [
+            Exact\CostsById::class,
+            ['entryId'],
+        ];
+        yield Exact\ReceivablesListByAccount::class => [
+            Exact\ReceivablesListByAccount::class,
+            ['accountId'],
+        ];
+        yield Exact\RevenueListByYear::class => [
+            Exact\RevenueListByYear::class,
+            ['year'],
+        ];
+        yield Exact\AgingOverviewByAccount::class => [
+            Exact\AgingOverviewByAccount::class,
+            ['accountId'],
+        ];
+        yield Exact\HourEntryRecentAccountsByProject::class => [
+            Exact\HourEntryRecentAccountsByProject::class,
+            ['projectId'],
+        ];
+        yield Exact\PayablesListByAccount::class => [
+            Exact\PayablesListByAccount::class,
+            ['accountId'],
+        ];
+        yield Exact\TimeAndBillingAccountDetailsByID::class => [
+            Exact\TimeAndBillingAccountDetailsByID::class,
+            ['accountId'],
+        ];
+        yield Exact\CostTypesByDate::class => [
+            Exact\CostTypesByDate::class,
+            ['checkDate'],
+        ];
+        yield Exact\HourEntryRecentHourTypesByProject::class => [
+            Exact\HourEntryRecentHourTypesByProject::class,
+            ['projectId'],
+        ];
+        yield Exact\OpportunityDocument::class => [
+            Exact\OpportunityDocument::class,
+            ['opportunityId', 'searchText'],
+        ];
+        yield Exact\TimeAndBillingEntryProjectsByDate::class => [
+            Exact\TimeAndBillingEntryProjectsByDate::class,
+            ['checkDate'],
+        ];
+        yield Exact\TimeAndBillingItemDetailsByID::class => [
+            Exact\TimeAndBillingItemDetailsByID::class,
+            ['itemId'],
+        ];
+        yield Exact\CostEntryExpensesByProject::class => [
+            Exact\CostEntryExpensesByProject::class,
+            ['projectId'],
+        ];
+        yield Exact\UserHasRights::class => [
+            Exact\UserHasRights::class,
+            ['endpoint', 'action'],
+        ];
+        yield Exact\TimeAndBillingEntryProjectsByAccountAndDate::class => [
+            Exact\TimeAndBillingEntryProjectsByAccountAndDate::class,
+            ['accountId', 'checkDate'],
+        ];
+        yield Exact\TimeAndBillingProjectDetailsByID::class => [
+            Exact\TimeAndBillingProjectDetailsByID::class,
+            ['projectId'],
+        ];
+        yield Exact\ItemDetailsByID::class => [
+            Exact\ItemDetailsByID::class,
+            ['itemId'],
+        ];
+        yield Exact\CostEntryRecentExpensesByProject::class => [
+            Exact\CostEntryRecentExpensesByProject::class,
+            ['projectId'],
         ];
     }
 }

--- a/tests/ResultsetTest.php
+++ b/tests/ResultsetTest.php
@@ -41,6 +41,6 @@ class ResultsetTest extends TestCase
         ))->nextAsGenerator();
 
         $this->assertIsIterable($response);
-        $this->assertCount(2, $response);
+        $this->assertEquals(2, iterator_count($response));
     }
 }

--- a/tests/ResultsetTest.php
+++ b/tests/ResultsetTest.php
@@ -11,7 +11,7 @@ class ResultsetTest extends TestCase
 {
     use MocksExactConnection;
 
-    public function testCanGetNext()
+    public function testCanGetNext(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);
@@ -28,7 +28,7 @@ class ResultsetTest extends TestCase
         $this->assertCount(2, $response);
     }
 
-    public function testCanGetNextAsGenerator()
+    public function testCanGetNextAsGenerator(): void
     {
         $handler = $this->createMockHandlerUsingFixture('items.json');
         $connection = $this->createMockConnection($handler);

--- a/tests/Support/MocksExactConnection.php
+++ b/tests/Support/MocksExactConnection.php
@@ -24,7 +24,7 @@ trait MocksExactConnection
     }
 
     /**
-     * @param GuzzleHttp\Psr7\Response|array|string|null $response
+     * @param \GuzzleHttp\Psr7\Response|array|string|null $response
      *
      * @return MockHandler
      */


### PR DESCRIPTION
This PR bumps the PHPUnit version to **9.6** which is the latest version with support for PHP 7.4 (minimum version PHP for this library). Bumping the version constraint required an update of the configuration file (`phpunit.xml.dist`) and also some warnings were triggered due to upcoming deprecations in PHPUnit 10.

Beside the above changes I've also taken the liberty to add return types where missing, update data providers to return a generator instead of arrays and correct a `@param` docblock 