### PR TITLE
Deprecate duplicate units class

### DIFF
--- a/src/Picqer/Financials/Exact/Units.php
+++ b/src/Picqer/Financials/Exact/Units.php
@@ -2,34 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        Units::class,
+        Unit::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class Units.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=LogisticsUnits
- *
- * @property string $ID Primary key
- * @property bool $Active Indicates whether a unit is in use
- * @property string $Code Unique code for the unit
- * @property string $Description Description
- * @property int $Division Division code
- * @property int $Main	Indicates the main unit per division. Will be used when creating new item
- * @property string $TimeUnit If Type = 'T' (time) then this fields indicates the type of time frame. yy = Year, mm = Month, wk = Week, dd = Day, hh = Hour, mi = Minute, ss = Second
- * @property string $Type Type 'Time' is especially important for contracts.
+ * @deprecated since 4.5.0, use \Picqer\Financials\Exact\Unit instead, to be removed in 5.0
  */
-class Units extends Model
+class Units extends Unit
 {
-    use Query\Findable;
-
-    protected $fillable = [
-        'ID',
-        'Active',
-        'Code',
-        'Description',
-        'Division',
-        'Main',
-        'TimeUnit',
-        'Type',
-    ];
-
-    protected $url = 'logistics/Units';
 }

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -36,6 +36,9 @@ class EntityTest extends TestCase
             'ApiException.php',
             'Model.php',
         ];
+        $deprecated = [
+            'Units.php',
+        ];
 
         while ($iterator->valid()) {
             /** @var \SplFileInfo $file */
@@ -45,9 +48,13 @@ class EntityTest extends TestCase
                 $iterator->next();
                 continue;
             }
+            if (in_array($file->getFilename(), $deprecated, true)) {
+                $iterator->next();
+                continue;
+            }
 
             $className = substr($file->getFilename(), 0, -4);
-            yield ["{$namespace}\\{$className}"];
+            yield $className => ["{$namespace}\\{$className}"];
             $iterator->next();
         }
     }


### PR DESCRIPTION
# Background
The `\Picqer\Financials\Exact\Units` class was added in 2017 in ad75b5c7 whereas the `Unit` (singular form) was added in 2019 (59dd5985). Following the naming conventions it should be a singular form. 

# PR Goal
This PR updates the `Units` class to become an extension of `Unit` and adds the deprecation trigger and annotation.
Once/If we agree on if this deprecation style is acceptable for this project I can update the other duplicate classes as well. First feedback is much appreciated. Also see below about the other class duplications.

# Additional info
There are multiple of these problems which can be discovered by running a bash command to find PHP files containing duplicate `@see` annotations in the `src` folder.
```bash
find ./src/Picqer/Financials/Exact -type f  -name \*.php | xargs grep '@see https://' -h | sort | uniq -c | grep '^   2'
```
<details><summary>See all duplicate @see notations</summary>
<p>
<pre>
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=DocumentsDocumentCategories
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=HRMDivisions
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=InventoryItemWarehousePlanningDetails
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=LogisticsUnits
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ProjectTimeTransactions
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadCRMDocumentsAttachments
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesShippingMethods
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncDeleted
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncInventoryItemWarehouses
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncInventoryStockPositions
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncInventoryStorageLocationStockPositions
   2  * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncProjectTimeCostTransactions
</pre>
</p>
</details> 