### PR TITLE
Add deprecations on incorrect class names

### DIFF
--- a/src/Picqer/Financials/Exact/Deleted.php
+++ b/src/Picqer/Financials/Exact/Deleted.php
@@ -2,34 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        Deleted::class,
+        SyncDeleted::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class Deleted.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncDeleted
- *
- * @property int $Timestamp Timestamp
- * @property string $DeletedBy UserID of person who deleted record
- * @property string $DeletedDate Deleted date
- * @property int $Division Division code
- * @property string $EntityKey Entity key
- * @property int $EntityType Entity Types: 1= TransactionLines 2= Accounts 3= Addresses 4= Attachments 5= Contacts 6= Documents 7= GLAccounts 8= SalesItemPrices 9= Items 10= PaymentTerms 11= Quotations 12= SalesOrders 13= SalesInvoices 14= TimeCostTransactions 15= StockPositions 16= GoodsDeliveries 17= GoodsDeliveryLines 18= GLClassifications 19= ItemWarehouses 20= StorageLocationStockPositions 21= Projects
- * @property string $ID Primary key
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\SyncDeleted instead, to be removed in 5.0
  */
-class Deleted extends Model
+class Deleted extends SyncDeleted
 {
-    use Query\Findable;
-
-    protected $primaryKey = 'Timestamp';
-
-    protected $fillable = [
-        'Timestamp',
-        'DeletedBy',
-        'DeletedDate',
-        'Division',
-        'EntityKey',
-        'EntityType',
-        'ID',
-    ];
-
-    protected $url = 'sync/Deleted';
 }

--- a/src/Picqer/Financials/Exact/DocumentCategorie.php
+++ b/src/Picqer/Financials/Exact/DocumentCategorie.php
@@ -2,27 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        DocumentCategorie::class,
+        DocumentCategory::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class DocumentCategorie.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=DocumentsDocumentCategories
- *
- * @property string $ID Primary key
- * @property string $Created Creation date
- * @property string $Description Document category description
- * @property string $Modified Last modified date
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\DocumentCategory instead, to be removed in 5.0
  */
-class DocumentCategorie extends Model
+class DocumentCategorie extends DocumentCategory
 {
-    use Query\Findable;
-    use Persistance\Storable;
-
-    protected $fillable = [
-        'ID',
-        'Created',
-        'Description',
-        'Modified',
-    ];
-
-    protected $url = 'documents/DocumentCategories';
 }

--- a/src/Picqer/Financials/Exact/DocumentsAttachment.php
+++ b/src/Picqer/Financials/Exact/DocumentsAttachment.php
@@ -2,28 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        DocumentsAttachment::class,
+        CrmDocumentAttachment::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class DocumentsAttachment.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ReadCRMDocumentsAttachments
- *
- * @property string $ID Primary key
- * @property string $AttachmentFileName Filename of the attachment
- * @property float $AttachmentFileSize File size of the attachment
- * @property string $AttachmentUrl Url for downloading the attachment. To get the file in its original format (xml, jpg, pdf, etc.) append &Download=1 to the url.
- * @property bool $CanShowInWebView
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\CrmDocumentAttachment instead, to be removed in 5.0
  */
-class DocumentsAttachment extends Model
+class DocumentsAttachment extends CrmDocumentAttachment
 {
-    use Query\Findable;
-
-    protected $fillable = [
-        'ID',
-        'AttachmentFileName',
-        'AttachmentFileSize',
-        'AttachmentUrl',
-        'CanShowInWebView',
-    ];
-
-    protected $url = 'read/crm/DocumentsAttachments';
 }

--- a/src/Picqer/Financials/Exact/HrmDivision.php
+++ b/src/Picqer/Financials/Exact/HrmDivision.php
@@ -2,86 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        HrmDivision::class,
+        Division::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class HrmDivision.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=HRMDivisions
- *
- * @property int $Code Primary key
- * @property string $ArchiveDate Date on which the division is archived
- * @property int $BlockingStatus Values: 0 = Not blocked, 1 = Backup/restore, 2 = Conversion busy, 3 = Conversion shadow, 4 = Conversion waiting, 5 = Copy data waiting, 6 = Copy data busy
- * @property DivisionClass[] $Class_01 First division classification. User should have access rights to view division classifications.
- * @property DivisionClass[] $Class_02 Second division classification. User should have access rights to view division classifications.
- * @property DivisionClass[] $Class_03 Third division classification. User should have access rights to view division classifications.
- * @property DivisionClass[] $Class_04 Fourth division classification. User should have access rights to view division classifications.
- * @property DivisionClass[] $Class_05 Fifth division classification. User should have access rights to view division classifications.
- * @property string $Country Country of the division. Is used for determination of legislation
- * @property string $CountryDescription Description of Country
- * @property string $Created Creation date
- * @property string $Creator User ID of creator
- * @property string $CreatorFullName Name of the creator
- * @property string $Currency Default currency of the division
- * @property string $CurrencyDescription Description of Currency
- * @property string $Customer Owner account of the division
- * @property string $CustomerCode Owner account code of the division
- * @property string $CustomerName Owner account name of the division
- * @property string $Description Description
- * @property int $HID Number that customers give to the division
- * @property bool $Main True for the main (hosting) division
- * @property string $Modified Last modified date
- * @property string $Modifier User ID of modifier
- * @property string $ModifierFullName Name of the last modifier
- * @property string $OBNumber The soletrader VAT number used for offical returns to tax authority
- * @property string $SiretNumber Siret Number of the division (France)
- * @property string $StartDate Date on which the division becomes active
- * @property int $Status Regular administrations will have status 0. Currently, the only other possibility is 'archived' (1), which means the administration is not actively used, but still needs to be accessible for the customer/accountant to meet legal obligations
- * @property string $TaxOfficeNumber Number of your local tax authority (Germany)
- * @property string $TaxReferenceNumber Local tax reference number (Germany)
- * @property string $TemplateCode Division template code
- * @property string $VATNumber VAT number
- * @property string $Website Customer value, hyperlink to external website
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\Division instead, to be removed in 5.0
  */
-class HrmDivision extends Model
+class HrmDivision extends Division
 {
-    use Query\Findable;
-
-    protected $primaryKey = 'Code';
-
-    protected $fillable = [
-        'Code',
-        'ArchiveDate',
-        'BlockingStatus',
-        'Class_01',
-        'Class_02',
-        'Class_03',
-        'Class_04',
-        'Class_05',
-        'Country',
-        'CountryDescription',
-        'Created',
-        'Creator',
-        'CreatorFullName',
-        'Currency',
-        'CurrencyDescription',
-        'Customer',
-        'CustomerCode',
-        'CustomerName',
-        'Description',
-        'HID',
-        'Main',
-        'Modified',
-        'Modifier',
-        'ModifierFullName',
-        'OBNumber',
-        'SiretNumber',
-        'StartDate',
-        'Status',
-        'TaxOfficeNumber',
-        'TaxReferenceNumber',
-        'TemplateCode',
-        'VATNumber',
-        'Website',
-    ];
-
-    protected $url = 'hrm/Divisions';
 }

--- a/src/Picqer/Financials/Exact/InventoryItemWarehouse.php
+++ b/src/Picqer/Financials/Exact/InventoryItemWarehouse.php
@@ -2,72 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        InventoryItemWarehouse::class,
+        SyncInventoryItemWarehouse::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class InventoryItemWarehouse.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncInventoryItemWarehouses
- *
- * @property int $Timestamp Timestamp
- * @property string $Created Creation date
- * @property string $Creator User ID of creator
- * @property string $CreatorFullName Name of creator
- * @property string $DefaultStorageLocation This is a default storage location
- * @property string $DefaultStorageLocationCode Default storage location's code
- * @property string $DefaultStorageLocationDescription Default storage location's description
- * @property int $Division Division code
- * @property string $ID A guid that is the unique identifier of the linkage between item and warehouse
- * @property string $Item Item ID
- * @property string $ItemCode Code of item
- * @property string $ItemDescription Description of item
- * @property float $MaximumStock Maximum quantity of items that you want in warehouse
- * @property string $Modified Last modified date
- * @property string $Modifier User ID of modifier
- * @property string $ModifierFullName Name of modifier
- * @property int $OrderPolicy Order Policy options: 1-Lot for lot, 2-Fixed order quantity, 3-Min / Max, 4-Order
- * @property int $Period Period that work together with replenishment in MRP
- * @property float $ReorderPoint Quantity of items as an indication of when you need to reorder more stock for the warehouse
- * @property float $ReorderQuantity Reorder quantity that work together with replenishment in MRP
- * @property int $ReplenishmentType Replenishment options: 1-Purchase, 2-Assemble, 3-Make, 4-Transfer, 5-No replenishment advice
- * @property float $ReservedStock The quantity in a back to back order process which is already received from the purchase order, but not yet delivered for the sales order.
- * @property float $SafetyStock Minimum quantity of items you must have in stock
- * @property string $Warehouse Warehouse ID
- * @property string $WarehouseCode Code of warehouse
- * @property string $WarehouseDescription Description of warehouse
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\SyncInventoryItemWarehouse instead, to be removed in 5.0
  */
-class InventoryItemWarehouse extends Model
+class InventoryItemWarehouse extends SyncInventoryItemWarehouse
 {
-    use Query\Findable;
-
-    protected $primaryKey = 'Timestamp';
-
-    protected $fillable = [
-        'Timestamp',
-        'Created',
-        'Creator',
-        'CreatorFullName',
-        'DefaultStorageLocation',
-        'DefaultStorageLocationCode',
-        'DefaultStorageLocationDescription',
-        'Division',
-        'ID',
-        'Item',
-        'ItemCode',
-        'ItemDescription',
-        'MaximumStock',
-        'Modified',
-        'Modifier',
-        'ModifierFullName',
-        'OrderPolicy',
-        'Period',
-        'ReorderPoint',
-        'ReorderQuantity',
-        'ReplenishmentType',
-        'ReservedStock',
-        'SafetyStock',
-        'Warehouse',
-        'WarehouseCode',
-        'WarehouseDescription',
-    ];
-
-    protected $url = 'sync/Inventory/ItemWarehouses';
 }

--- a/src/Picqer/Financials/Exact/ItemWarehousePlanningDetails.php
+++ b/src/Picqer/Financials/Exact/ItemWarehousePlanningDetails.php
@@ -2,48 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        ItemWarehousePlanningDetails::class,
+        ItemWarehousePlanningDetail::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class ItemWarehousePlanningDetails.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=InventoryItemWarehousePlanningDetails
- *
- * @property string $Item Primary key
- * @property string $ItemCode Code of item
- * @property string $ItemDescription Description of item
- * @property string $PlannedDate Date which quantity in stock is planned to change
- * @property float $PlannedQuantity Amount by which quantity in stock is planned to change
- * @property string $PlanningSourceDescription Human readable description of the PlanningSource (translated to user's language) - Examples: Purchase Order, Sales Order, Shop Order, etc.
- * @property string $PlanningSourceID ID of the PlanningSource
- * @property int $PlanningSourceLineNumber Line number of the PlanningSource if the PlanningSourceType supports line numbers
- * @property int $PlanningSourceNumber Human readable number of the PlanningSource - Examples: Shop order number '201600001' or Sales order number '2016020001'
- * @property string $PlanningSourceUrl REST API URL of this specific PlanningSource and PlanningSourceID (Assembly orders and warehouse transfers not supported over REST)
- * @property int $PlanningType Type of the PlanningSource - 120=GoodsDelivery, 124=WarehouseTransferDelivery, 130=GoodsReceipt, 134=WarehouseTransferReceipt, 140=ShopOrderStockReceipt, 147=ShopOrderByProductReceipt, 150=ShopOrderRequirement, 160=AssemblyOrderReceipt, 165=AssemblyOrderIssue
- * @property string $PlanningTypeDescription Human readable description of the PlanningSourceType (translated to user's language) - Examples: 'Shop order stock receipt' or 'Goods delivery'
- * @property string $Warehouse ID of warehouse
- * @property string $WarehouseCode Code of warehouse
- * @property string $WarehouseDescription Description of warehouse
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\ItemWarehousePlanningDetail instead, to be removed in 5.0
  */
-class ItemWarehousePlanningDetails extends Model
+class ItemWarehousePlanningDetails extends ItemWarehousePlanningDetail
 {
-    use Query\Findable;
-    use Persistance\Storable;
-
-    protected $fillable = [
-        'Item',
-        'ItemCode',
-        'ItemDescription',
-        'PlannedDate',
-        'PlannedQuantity',
-        'PlanningSourceDescription',
-        'PlanningSourceID',
-        'PlanningSourceLineNumber',
-        'PlanningSourceUrl',
-        'PlanningType',
-        'PlanningTypeDescription',
-        'Warehouse',
-        'WarehouseCode',
-        'WarehouseDescription',
-    ];
-
-    protected $url = 'inventory/ItemWarehousePlanningDetails';
 }

--- a/src/Picqer/Financials/Exact/ProjectTimeTransactions.php
+++ b/src/Picqer/Financials/Exact/ProjectTimeTransactions.php
@@ -2,103 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        ProjectTimeTransactions::class,
+        ProjectTimeTransaction::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class ProjectTimeTransactions.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=ProjectTimeTransactions
- *
- * @property string $ID Primary key
- * @property string $Account Guid ID of account that is linked to the project
- * @property string $AccountName Name of account that is linked to the project
- * @property string $Activity Guid ID of activity that is linked to project WBS (work breakdown structure)
- * @property string $ActivityDescription Name of activity that is linked to project WBS (work breakdown structure)
- * @property float $AmountFC Calculated amount of the transaction based on (Quantity * PriceFC)
- * @property string $Attachment Attachment linked to the transaction (not mandatory)
- * @property string $Created Date and time the transaction was created
- * @property string $Creator The Guid ID of user that created the transaction
- * @property string $CreatorFullName The full name of the user that created the record
- * @property string $Currency Currency of amount FC
- * @property string $Date Date and time the time transaction was done
- * @property int $Division Division code
- * @property string $DivisionDescription Description of Division
- * @property string $Employee Guid ID of the employee that is linked to the time transaction
- * @property string $EndTime End time of the time transaction
- * @property int $EntryNumber Number that represents the grouping of time transactions
- * @property string $ErrorText (Only used by backgroundjobs) To determine which transaction has an error
- * @property int $HourStatus Status of the transaction: 1 = Draft, 2 = Rejected, 10 = Submitted, 11 = Failed on approval, 14 = Processing, 16 = Processing, 19 = Failed while undoing approval, 20 = Final
- * @property string $Item Item that is linked to the transaction, which provides the time information
- * @property string $ItemDescription Description of the item that is linked to the transaction
- * @property bool $ItemDivisable Indicates if fractional quantities of the item can be used, for example quantity = 0.4
- * @property string $Modified The date and time transaction record was modified
- * @property string $Modifier The Guid ID of the user that modified the records
- * @property string $ModifierFullName The full name of the user that modified the record
- * @property string $Notes Notes linked to the transaction for providing additional information (not mandatory)
- * @property float $PriceFC For use in AmountFC (Quantiy * Price FC)
- * @property string $Project Guid ID of project that is linked to the transaction
- * @property string $ProjectAccount Project account ID that is linked to the transaction (not mandatory)
- * @property string $ProjectAccountCode Project account code that is linked to the transaction
- * @property string $ProjectAccountName Project account name that is linked to the transaction
- * @property string $ProjectCode Project code that is linked to the transaction
- * @property string $ProjectDescription Project description that is linked to the transaction
- * @property float $Quantity Quantity of the item that is linked to the transaction
- * @property string $StartTime Start time of the time transaction
- * @property string $Subscription Guid ID of subscription that is linked to the transaction
- * @property string $SubscriptionAccount Subscription account ID that is linked to the transaction, this is to identify the referenced subscription
- * @property string $SubscriptionAccountCode Subscription account code that is linked to the transaction
- * @property string $SubscriptionAccountName Subscription account name that is linked to the transaction
- * @property string $SubscriptionDescription Subscription description that is linked to the transaction
- * @property int $SubscriptionNumber Subscription number that is linked to the transaction
- * @property int $Type The type of transaction. E.g: 1 = Time, 2 = Cost
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\ProjectTimeTransaction instead, to be removed in 5.0
  */
-class ProjectTimeTransactions extends Model
+class ProjectTimeTransactions extends ProjectTimeTransaction
 {
-    use Query\Findable;
-    use Persistance\Storable;
-
-    protected $fillable = [
-        'ID',
-        'Account',
-        'AccountName',
-        'Activity',
-        'ActivityDescription',
-        'AmountFC',
-        'Attachment',
-        'Created',
-        'Creator',
-        'CreatorFullName',
-        'Currency',
-        'Date',
-        'Division',
-        'DivisionDescription',
-        'Employee',
-        'EndTime',
-        'EntryNumber',
-        'ErrorText',
-        'HourStatus',
-        'Item',
-        'ItemDescription',
-        'ItemDivisable',
-        'Modified',
-        'Modifier',
-        'ModifierFullName',
-        'Notes',
-        'PriceFC',
-        'Project',
-        'ProjectAccount',
-        'ProjectAccountCode',
-        'ProjectAccountName',
-        'ProjectCode',
-        'ProjectDescription',
-        'Quantity',
-        'StartTime',
-        'Subscription',
-        'SubscriptionAccount',
-        'SubscriptionAccountCode',
-        'SubscriptionAccountName',
-        'SubscriptionDescription',
-        'SubscriptionNumber',
-        'Type',
-    ];
-
-    protected $url = 'project/TimeTransactions';
 }

--- a/src/Picqer/Financials/Exact/SalesShippingMethod.php
+++ b/src/Picqer/Financials/Exact/SalesShippingMethod.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Picqer\Financials\Exact;
+
+/**
+ * Class Item.
+ *
+ * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesShippingMethods
+ *
+ * @property string $ID Primary key
+ * @property bool $Active Active
+ * @property string $Code Code of the shipping method
+ * @property string $Created Creation date
+ * @property string $Creator User ID of creator
+ * @property string $CreatorFullName Name of creator
+ * @property string $Description Description of shipping method
+ * @property int $Division Division code
+ * @property string $Modified Last modified date
+ * @property string $Modifier User ID of modifier
+ * @property string $ModifierFullName Name of modifier
+ * @property string $Notes Notes
+ * @property string $ShippingRatesURL Shipping method rates URL
+ * @property string $TrackingURL Tracking URL
+ */
+class SalesShippingMethod extends Model
+{
+    use Query\Findable;
+    use Persistance\Storable;
+
+    protected $fillable = [
+        'ID',
+        'Active',
+        'Code',
+        'Created',
+        'Creator',
+        'CreatorFullName',
+        'Description',
+        'Division',
+        'Modified',
+        'Modifier',
+        'ModifierFullName',
+        'Notes',
+        'ShippingRatesURL',
+        'TrackingURL',
+    ];
+
+    protected $url = 'sales/ShippingMethods';
+}

--- a/src/Picqer/Financials/Exact/SalesShippingMethods.php
+++ b/src/Picqer/Financials/Exact/SalesShippingMethods.php
@@ -2,47 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        SalesShippingMethods::class,
+        SalesShippingMethod::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class Item.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesShippingMethods
- *
- * @property string $ID Primary key
- * @property bool $Active Active
- * @property string $Code Code of the shipping method
- * @property string $Created Creation date
- * @property string $Creator User ID of creator
- * @property string $CreatorFullName Name of creator
- * @property string $Description Description of shipping method
- * @property int $Division Division code
- * @property string $Modified Last modified date
- * @property string $Modifier User ID of modifier
- * @property string $ModifierFullName Name of modifier
- * @property string $Notes Notes
- * @property string $ShippingRatesURL Shipping method rates URL
- * @property string $TrackingURL Tracking URL
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\SalesShippingMethod instead, to be removed in 5.0
  */
-class SalesShippingMethods extends Model
+class SalesShippingMethods extends SalesShippingMethod
 {
-    use Query\Findable;
-    use Persistance\Storable;
-
-    protected $fillable = [
-        'ID',
-        'Active',
-        'Code',
-        'Created',
-        'Creator',
-        'CreatorFullName',
-        'Description',
-        'Division',
-        'Modified',
-        'Modifier',
-        'ModifierFullName',
-        'Notes',
-        'ShippingRatesURL',
-        'TrackingURL',
-    ];
-
-    protected $url = 'sales/ShippingMethods';
 }

--- a/src/Picqer/Financials/Exact/ShippingMethod.php
+++ b/src/Picqer/Financials/Exact/ShippingMethod.php
@@ -2,54 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        ShippingMethod::class,
+        SalesShippingMethod::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class ShippingMethod.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SalesShippingMethods
- *
- * @property string $ID Primary key
- * @property bool $Active Active
- * @property float $Amount Amount of Shipping Cost
- * @property string $Code Code of the shipping method
- * @property string $Created Creation date
- * @property string $Creator User ID of creator
- * @property string $CreatorFullName Name of creator
- * @property string $Description Description of shipping method
- * @property int $Division Division code
- * @property string $Modified Last modified date
- * @property string $Modifier User ID of modifier
- * @property string $ModifierFullName Name of modifier
- * @property string $Notes Notes
- * @property string $ShippingRatesURL Shipping method rates URL
- * @property string $TrackingURL Tracking URL
- * @property string $VATCode VAT Code
- * @property string $VATCodeDescription Description of VAT Code
- * @property float $VATPercentage The VAT Percentage of the VAT code
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\SalesShippingMethod instead, to be removed in 5.0
  */
-class ShippingMethod extends Model
+class ShippingMethod extends SalesShippingMethod
 {
-    use Query\Findable;
-
-    protected $fillable = [
-        'ID',
-        'Active',
-        'Amount',
-        'Code',
-        'Created',
-        'Creator',
-        'CreatorFullName',
-        'Description',
-        'Division',
-        'Modified',
-        'Modifier',
-        'ModifierFullName',
-        'Notes',
-        'ShippingRatesURL',
-        'TrackingURL',
-        'VATCode',
-        'VATCodeDescription',
-        'VATPercentage',
-    ];
-
-    protected $url = 'sales/ShippingMethods';
 }

--- a/src/Picqer/Financials/Exact/StorageLocationStockPosition.php
+++ b/src/Picqer/Financials/Exact/StorageLocationStockPosition.php
@@ -2,50 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        StorageLocationStockPosition::class,
+        SyncStorageLocationStockPosition::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class StorageLocationStockPosition.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncInventoryStorageLocationStockPositions
- *
- * @property int $Timestamp Timestamp
- * @property int $Division Division code
- * @property string $ID Primary key
- * @property string $Item Item
- * @property string $ItemCode Code of the item
- * @property string $ItemDescription Description of the item
- * @property float $Stock Stock
- * @property string $StorageLocation Storage location
- * @property string $StorageLocationCode Code of the storage location
- * @property string $StorageLocationDescription Description of the storage location
- * @property string $UnitCode Code of the unit for the item
- * @property string $UnitDescription Description of the unit for the item
- * @property string $Warehouse Warehouse
- * @property string $WarehouseCode Code of the warehouse
- * @property string $WarehouseDescription Description of the warehouse
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\SyncStorageLocationStockPosition instead, to be removed in 5.0
  */
-class StorageLocationStockPosition extends Model
+class StorageLocationStockPosition extends SyncStorageLocationStockPosition
 {
-    use Query\Findable;
-
-    protected $primaryKey = 'Timestamp';
-
-    protected $fillable = [
-        'Timestamp',
-        'Division',
-        'ID',
-        'Item',
-        'ItemCode',
-        'ItemDescription',
-        'Stock',
-        'StorageLocation',
-        'StorageLocationCode',
-        'StorageLocationDescription',
-        'UnitCode',
-        'UnitDescription',
-        'Warehouse',
-        'WarehouseCode',
-        'WarehouseDescription',
-    ];
-
-    protected $url = 'sync/Inventory/StorageLocationStockPositions';
 }

--- a/src/Picqer/Financials/Exact/SyncStockPosition.php
+++ b/src/Picqer/Financials/Exact/SyncStockPosition.php
@@ -2,56 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        SyncStockPosition::class,
+        SyncInventoryStockPosition::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class SyncStockPosition.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncInventoryStockPositions
- *
- * @property int $Timestamp Timestamp
- * @property float $CurrentStock Number of items in stock
- * @property int $Division Division code
- * @property float $FreeStock Quantity of available stock
- * @property string $ID Primary Key
- * @property string $ItemCode Code of the item
- * @property string $ItemDescription Description of the item
- * @property string $ItemId A guid that is the unique identifier of the item
- * @property float $PlanningIn Number of items that are planned to come in
- * @property float $PlanningOut Number of items that are planned to go out
- * @property float $ProjectedStock The quantity of stock projected given all planned future stock changes
- * @property float $ReorderPoint Quantity of items as an indication of when you need to reorder more stock for the warehouse
- * @property float $ReservedStock Stock stored in the warehouse that is already reserved
- * @property string $UnitCode Code of item unit
- * @property string $UnitDescription Description of the item unit
- * @property string $Warehouse A guid that is the unique identifier of the warehouse
- * @property string $WarehouseCode Code of warehouse
- * @property string $WarehouseDescription Description of warehouse
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\SyncInventoryStockPosition instead, to be removed in 5.0
  */
-class SyncStockPosition extends Model
+class SyncStockPosition extends SyncInventoryStockPosition
 {
-    use Query\Findable;
-
-    protected $primaryKey = 'Timestamp';
-
-    protected $fillable = [
-        'Timestamp',
-        'CurrentStock',
-        'Division',
-        'FreeStock',
-        'ID',
-        'ItemCode',
-        'ItemDescription',
-        'ItemId',
-        'PlanningIn',
-        'PlanningOut',
-        'ProjectedStock',
-        'ReorderPoint',
-        'ReservedStock',
-        'UnitCode',
-        'UnitDescription',
-        'Warehouse',
-        'WarehouseCode',
-        'WarehouseDescription',
-    ];
-
-    protected $url = 'sync/Inventory/StockPositions';
 }

--- a/src/Picqer/Financials/Exact/TimeCostTransaction.php
+++ b/src/Picqer/Financials/Exact/TimeCostTransaction.php
@@ -2,106 +2,18 @@
 
 namespace Picqer\Financials\Exact;
 
+trigger_error(
+    sprintf(
+        '"%s" is deprecated due to an invalid naming convention, use "%s" instead',
+        TimeCostTransaction::class,
+        SyncTimeCostTransaction::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class TimeCostTransaction.
- *
- * @see https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SyncProjectTimeCostTransactions
- *
- * @property int $Timestamp Timestamp
- * @property string $Account Guid ID of account that is linked to the project
- * @property string $AccountName Name of account that is linked to the project
- * @property float $AmountFC Calculated amount of the transaction based on (Quantity * PriceFC)
- * @property string $Attachment Attachment linked to the transaction (not mandatory)
- * @property string $Created Date and time the transaction was created
- * @property string $Creator The Guid ID of user that created the transaction
- * @property string $CreatorFullName The full name of the user that created the record
- * @property string $Currency Currency of amount FC
- * @property string $Date Date and time the transaction was done
- * @property int $Division Division code
- * @property string $DivisionDescription Description of Division
- * @property string $Employee Guid ID of the employee that is linked to the transaction
- * @property string $EndTime End time of the time transaction
- * @property int $EntryNumber Number that represents the grouping of transactions
- * @property string $ErrorText (Only used by backgroundjobs) To determine which transaction has an error
- * @property int $HourStatus Status of the transaction: 1 = Draft, 2 = Rejected, 10 = Submitted, 11 = Failed on approval, 14 = Processing, 16 = Processing, 19 = Failed while undoing approval, 20 = Final
- * @property string $ID Primary key
- * @property string $Item Item that is linked to the transaction, which provides the time or cost information
- * @property string $ItemDescription Description of the item that is linked to the transaction
- * @property bool $ItemDivisable Indicates if fractional quantities of the item can be used, for example quantity = 0.4
- * @property string $Modified The date and time transaction record was modified
- * @property string $Modifier The Guid ID of the user that modified the records
- * @property string $ModifierFullName The full name of the user that modified the record
- * @property string $Notes Notes linked to the transaction for providing additional information (not mandatory)
- * @property float $PriceFC For use in AmountFC (Quantiy * Price FC)
- * @property string $Project Guid ID of project that is linked to the transaction
- * @property string $ProjectAccount Project account ID that is linked to the transaction (not mandatory)
- * @property string $ProjectAccountCode Project account code that is linked to the transaction
- * @property string $ProjectAccountName Project account name that is linked to the transaction
- * @property string $ProjectCode Project code that is linked to the transaction
- * @property string $ProjectDescription Project description that is linked to the transaction
- * @property float $Quantity Quantity of the item that is linked to the transaction
- * @property string $StartTime Start time of the time transaction
- * @property string $Subscription Guid ID of subscription that is linked to the transaction
- * @property string $SubscriptionAccount Subscription account ID that is linked to the transaction, this is to identify the referenced subscription
- * @property string $SubscriptionAccountCode Subscription account code that is linked to the transaction
- * @property string $SubscriptionAccountName Subscription account name that is linked to the transaction
- * @property string $SubscriptionDescription Subscription description that is linked to the transaction
- * @property int $SubscriptionNumber Subscription number that is linked to the transaction
- * @property int $Type The type of transaction. E.g: 1 = Time, 2 = Cost
- * @property string $WBS Guid ID of activity for time transaction or expense for cost transaction that is linked to project WBS (work breakdown structure)
- * @property string $WBSDescription Name of activity for time transaction or expense for cost transaction that is linked to project WBS (work breakdown structure)
+ * @deprecated since 4.5.2, use \Picqer\Financials\Exact\SyncTimeCostTransaction instead, to be removed in 5.0
  */
-class TimeCostTransaction extends Model
+class TimeCostTransaction extends SyncTimeCostTransaction
 {
-    use Query\Findable;
-
-    protected $primaryKey = 'Timestamp';
-
-    protected $fillable = [
-        'Timestamp',
-        'Account',
-        'AccountName',
-        'AmountFC',
-        'Attachment',
-        'Created',
-        'Creator',
-        'CreatorFullName',
-        'Currency',
-        'Date',
-        'Division',
-        'DivisionDescription',
-        'Employee',
-        'EndTime',
-        'EntryNumber',
-        'ErrorText',
-        'HourStatus',
-        'ID',
-        'Item',
-        'ItemDescription',
-        'ItemDivisable',
-        'Modified',
-        'Modifier',
-        'ModifierFullName',
-        'Notes',
-        'PriceFC',
-        'Project',
-        'ProjectAccount',
-        'ProjectAccountCode',
-        'ProjectAccountName',
-        'ProjectCode',
-        'ProjectDescription',
-        'Quantity',
-        'StartTime',
-        'Subscription',
-        'SubscriptionAccount',
-        'SubscriptionAccountCode',
-        'SubscriptionAccountName',
-        'SubscriptionDescription',
-        'SubscriptionNumber',
-        'Type',
-        'WBS',
-        'WBSDescription',
-    ];
-
-    protected $url = 'sync/Project/TimeCostTransactions';
 }

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -37,6 +37,18 @@ class EntityTest extends TestCase
             'Model.php',
         ];
         $deprecated = [
+            'Deleted.php',
+            'DocumentsAttachment.php',
+            'DocumentCategorie.php',
+            'HrmDivision.php',
+            'InventoryItemWarehouse.php',
+            'ItemWarehousePlanningDetails.php',
+            'ProjectTimeTransactions.php',
+            'SalesShippingMethods.php',
+            'ShippingMethod.php',
+            'StorageLocationStockPosition.php',
+            'SyncStockPosition.php',
+            'TimeCostTransaction.php',
             'Units.php',
         ];
 


### PR DESCRIPTION
This is a follow up on #675 deprecating the remaining classes pointed out in my description. Since the changes have been merged uncommented I've taken a leap of faith that these would be okay as well (let me know if you think differently).

# Copilot summary:
This pull request includes several changes to deprecate classes with invalid naming conventions and replace them with correctly named classes. Each deprecated class now triggers a deprecation warning and extends the new class. The most important changes include the deprecation of classes such as `Deleted`, `DocumentCategorie`, `DocumentsAttachment`, `HrmDivision`, and `InventoryItemWarehouse`.

Deprecation of classes with invalid naming conventions:

* [`src/Picqer/Financials/Exact/Deleted.php`](diffhunk://#diff-7de890c6ea205ecc2f67f927313a614145a5b301b8b1c32e8d7bc3e293072e91R5-L34): Deprecated the `Deleted` class and replaced it with `SyncDeleted`. Added a deprecation warning. (`[src/Picqer/Financials/Exact/Deleted.phpR5-L34](diffhunk://#diff-7de890c6ea205ecc2f67f927313a614145a5b301b8b1c32e8d7bc3e293072e91R5-L34)`)
* [`src/Picqer/Financials/Exact/DocumentCategorie.php`](diffhunk://#diff-c65e5aa321acc813022346e486175d6a1bafe17fd3fdabe8993fe739855473cbR5-L27): Deprecated the `DocumentCategorie` class and replaced it with `DocumentCategory`. Added a deprecation warning. (`[src/Picqer/Financials/Exact/DocumentCategorie.phpR5-L27](diffhunk://#diff-c65e5aa321acc813022346e486175d6a1bafe17fd3fdabe8993fe739855473cbR5-L27)`)
* [`src/Picqer/Financials/Exact/DocumentsAttachment.php`](diffhunk://#diff-8f0ba86d4c7e3b208bba60e79655922eeee8c8b101af6e1c8e64b3b68d0e23a1R5-L28): Deprecated the `DocumentsAttachment` class and replaced it with `CrmDocumentAttachment`. Added a deprecation warning. (`[src/Picqer/Financials/Exact/DocumentsAttachment.phpR5-L28](diffhunk://#diff-8f0ba86d4c7e3b208bba60e79655922eeee8c8b101af6e1c8e64b3b68d0e23a1R5-L28)`)
* [`src/Picqer/Financials/Exact/HrmDivision.php`](diffhunk://#diff-bf69e63038bd26c58e847931c9acc6c20c31729e9651441aa8f295c65933952dR5-L86): Deprecated the `HrmDivision` class and replaced it with `Division`. Added a deprecation warning. (`[src/Picqer/Financials/Exact/HrmDivision.phpR5-L86](diffhunk://#diff-bf69e63038bd26c58e847931c9acc6c20c31729e9651441aa8f295c65933952dR5-L86)`)
* [`src/Picqer/Financials/Exact/InventoryItemWarehouse.php`](diffhunk://#diff-9c8e05d1c24f0951e2042bd457c605107304a746834ad3144e069dfe94d046f2R5-L72): Deprecated the `InventoryItemWarehouse` class and replaced it with `SyncInventoryItemWarehouse`. Added a deprecation warning. (`[src/Picqer/Financials/Exact/InventoryItemWarehouse.phpR5-L72](diffhunk://#diff-9c8e05d1c24f0951e2042bd457c605107304a746834ad3144e069dfe94d046f2R5-L72)`)